### PR TITLE
[59707] Java SDK support for metadata for events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build
 .project
 .settings
 bin
+
+# Ignore Intellij files
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
-- Calendar.isPrimary field is now available
 - Add `metadata` field in the Event model to support new event metadata
 - Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This section contains changes that have been committed but not yet released.
 ### Added
 
 - Calendar.isPrimary field is now available
+- Add `metadata` field in the Event model to support new event metadata
+- Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`
 
 ### Changed
 

--- a/src/examples/java/com/nylas/examples/other/DocExamples.java
+++ b/src/examples/java/com/nylas/examples/other/DocExamples.java
@@ -8,6 +8,8 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.nylas.Contact;
 import com.nylas.Draft;
@@ -220,6 +222,12 @@ public class DocExamples {
 		event.setLocation("My House!");
 		event.setDescription("Let's celebrate our calendar integration!!");
 		event.setBusy(true);
+
+		// Metadata can be added to an event to store extra information and
+		// add custom fields. You can also query on metadata by keys, values, and key-value pairs
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("event_category", "gathering");
+		event.setMetadata(metadata);
 
 		// Participants are added as a list of Participant objects, which require email
 		// and may contain name, status, or comment as well

--- a/src/examples/java/com/nylas/examples/other/EventsExample.java
+++ b/src/examples/java/com/nylas/examples/other/EventsExample.java
@@ -6,7 +6,9 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.nylas.Calendar;
 import com.nylas.Event;
@@ -53,7 +55,7 @@ public class EventsExample {
 				.startsAfter(Instant.now())
 				.startsBefore(Instant.now().plus(30, ChronoUnit.DAYS ))
 				.limit(50);
-		
+
 		for (Event event : events.list(query)) {
 			System.out.println("event: " + event);
 		}
@@ -95,6 +97,11 @@ public class EventsExample {
 		created.setLocation("Lake Merritt");
 		created.setParticipants(Arrays.asList(partier, partier1, partier2, partier3));
 		created.setRecurrence(new Recurrence(startTz.getId(), Arrays.asList("RRULE:FREQ=WEEKLY;BYDAY=TH")));
+
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("event_category", "gathering");
+		created.setMetadata(metadata);
+
 		Event updated = events.update(created, true);
 		System.out.println("Updated: " + updated);
 		

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -23,6 +23,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	private String status;
 	private Boolean read_only;
 	private Boolean busy;
+	private Map<String, Object> metadata;
 	
 	private Recurrence recurrence;
 	
@@ -85,6 +86,10 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		return busy;
 	}
 
+	public Map<String, Object> getMetadata() {
+		return metadata;
+	}
+
 	public Recurrence getRecurrence() {
 		return recurrence;
 	}
@@ -105,7 +110,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	public String toString() {
 		return "Event [id=" + getId() + ", calendar_id=" + calendar_id + ", ical_uid=" + ical_uid + ", title=" + title
 				+ ", when=" + when + ", location=" + location + ", owner=" + owner + ", participants=" + participants
-				+ ", status=" + status + ", read_only=" + read_only + ", busy=" + busy + ", recurrence=" + recurrence
+				+ ", status=" + status + ", read_only=" + read_only + ", busy=" + busy + ", metadata=" + metadata + ", recurrence=" + recurrence
 				+ ", master_event_id=" + master_event_id + ", original_start_time=" + getOriginalStartTime() + "]";
 	}
 
@@ -133,6 +138,10 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		this.busy = busy;
 	}
 
+	public void setMetadata(Map<String, Object> metadata) {
+		this.metadata = metadata;
+	}
+
 	public void setRecurrence(Recurrence recurrence) {
 		this.recurrence = recurrence;
 	}
@@ -149,6 +158,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		Maps.putIfNotNull(params, "location", getLocation());
 		Maps.putIfNotNull(params, "participants", getParticipants());
 		Maps.putIfNotNull(params, "busy", getBusy());
+		Maps.putIfNotNull(params, "metadata", getMetadata());
 		Maps.putIfNotNull(params, "recurrence", getRecurrence());
 		return params;
 	}

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -23,7 +23,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	private String status;
 	private Boolean read_only;
 	private Boolean busy;
-	private Map<String, Object> metadata;
+	private Map<String, String> metadata;
 	
 	private Recurrence recurrence;
 	
@@ -86,7 +86,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		return busy;
 	}
 
-	public Map<String, Object> getMetadata() {
+	public Map<String, String> getMetadata() {
 		return metadata;
 	}
 
@@ -138,7 +138,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		this.busy = busy;
 	}
 
-	public void setMetadata(Map<String, Object> metadata) {
+	public void setMetadata(Map<String, String> metadata) {
 		this.metadata = metadata;
 	}
 

--- a/src/main/java/com/nylas/EventQuery.java
+++ b/src/main/java/com/nylas/EventQuery.java
@@ -1,6 +1,8 @@
 package com.nylas;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import okhttp3.HttpUrl;
 
@@ -17,6 +19,9 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	private Instant startsAfter;
 	private Instant endsBefore;
 	private Instant endsAfter;
+	private String[] metadataKey;
+	private String[] metadataValue;
+	private Map<String, String> metadataPair;
 
 	@Override
 	public void addParameters(HttpUrl.Builder url) {
@@ -54,6 +59,21 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 		}
 		if (endsAfter != null) {
 			url.addQueryParameter("ends_after", Instants.formatEpochSecond(endsAfter));
+		}
+		if (metadataKey != null) {
+			for(String key : metadataKey) {
+				url.addQueryParameter("metadata_key", key);
+			}
+		}
+		if (metadataValue != null) {
+			for(String value : metadataValue) {
+				url.addQueryParameter("metadata_value", value);
+			}
+		}
+		if (metadataPair != null) {
+			for (Entry<String, String> pair : metadataPair.entrySet()) {
+				url.addQueryParameter("metadata_pair", String.format("%s:%s", pair.getKey(), pair.getValue()));
+			}
 		}
 	}
 	
@@ -109,6 +129,21 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	
 	public EventQuery endsAfter(Instant endsAfter) {
 		this.endsAfter = endsAfter;
+		return this;
+	}
+
+	public EventQuery metadataKey(String... metadataKey) {
+		this.metadataKey = metadataKey;
+		return this;
+	}
+
+	public EventQuery metadataValue(String... metadataValue) {
+		this.metadataValue = metadataValue;
+		return this;
+	}
+
+	public EventQuery metadataPair(Map<String, String> metadataPair) {
+		this.metadataPair = metadataPair;
 		return this;
 	}
 	

--- a/src/main/java/com/nylas/EventQuery.java
+++ b/src/main/java/com/nylas/EventQuery.java
@@ -1,8 +1,9 @@
 package com.nylas;
 
 import java.time.Instant;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import okhttp3.HttpUrl;
 
@@ -19,9 +20,9 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	private Instant startsAfter;
 	private Instant endsBefore;
 	private Instant endsAfter;
-	private String[] metadataKey;
-	private String[] metadataValue;
-	private Map<String, String> metadataPair;
+	private List<String> metadataKeys;
+	private List<String> metadataValues;
+	private List<String> metadataPairs;
 
 	@Override
 	public void addParameters(HttpUrl.Builder url) {
@@ -60,19 +61,19 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 		if (endsAfter != null) {
 			url.addQueryParameter("ends_after", Instants.formatEpochSecond(endsAfter));
 		}
-		if (metadataKey != null) {
-			for(String key : metadataKey) {
+		if (metadataKeys != null) {
+			for(String key : metadataKeys) {
 				url.addQueryParameter("metadata_key", key);
 			}
 		}
-		if (metadataValue != null) {
-			for(String value : metadataValue) {
+		if (metadataValues != null) {
+			for(String value : metadataValues) {
 				url.addQueryParameter("metadata_value", value);
 			}
 		}
-		if (metadataPair != null) {
-			for (Entry<String, String> pair : metadataPair.entrySet()) {
-				url.addQueryParameter("metadata_pair", String.format("%s:%s", pair.getKey(), pair.getValue()));
+		if (metadataPairs != null) {
+			for(String value : metadataPairs) {
+				url.addQueryParameter("metadata_pair", value);
 			}
 		}
 	}
@@ -132,19 +133,48 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 		return this;
 	}
 
+	/**
+	 * Add required metadata key to the query.
+	 * Returned events must include a metadata property with this key.
+	 * This method can accept multiple strings or be invoked multiple times
+	 * for the event to have multiple metadata keys. Each time this is called it
+	 * adds another required value rather than replacing previous required keys.
+	 */
 	public EventQuery metadataKey(String... metadataKey) {
-		this.metadataKey = metadataKey;
+		if (this.metadataKeys == null) {
+			this.metadataKeys = new ArrayList<>();
+		}
+		this.metadataKeys.addAll(Arrays.asList(metadataKey));
 		return this;
 	}
 
+	/**
+	 * Add required metadata value to the query.
+	 * Returned events must include a metadata property with this value.
+	 * This method can accept multiple strings or be invoked multiple times
+	 * for the event to have multiple metadata values. Each time this is called it
+	 * adds another required value rather than replacing previous required values.
+	 */
 	public EventQuery metadataValue(String... metadataValue) {
-		this.metadataValue = metadataValue;
+		if (this.metadataValues == null) {
+			this.metadataValues = new ArrayList<>();
+		}
+		this.metadataValues.addAll(Arrays.asList(metadataValue));
 		return this;
 	}
 
-	public EventQuery metadataPair(Map<String, String> metadataPair) {
-		this.metadataPair = metadataPair;
+	/**
+	 * Add a required metadata key/value pair to the query.
+	 * Returned events must include a metadata property with this key and value.
+	 * This method can be invoked multiple times to require the event to have multiple
+	 * metadata key value pairs.  Each time this is called it adds another required key value pair rather than
+	 * replacing previous required key value pairs.
+	 */
+	public EventQuery metadataPair(String key, String value) {
+		if (this.metadataPairs == null) {
+			this.metadataPairs = new ArrayList<>();
+		}
+		this.metadataPairs.add(key + ":" + value);
 		return this;
 	}
-	
 }

--- a/src/main/java/com/nylas/EventQuery.java
+++ b/src/main/java/com/nylas/EventQuery.java
@@ -134,11 +134,11 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	}
 
 	/**
-	 * Add required metadata key to the query.
-	 * Returned events must include a metadata property with this key.
-	 * This method can accept multiple strings or be invoked multiple times
-	 * for the event to have multiple metadata keys. Each time this is called it
-	 * adds another required value rather than replacing previous required keys.
+	 * Return events with metadata containing a property having the given key.
+	 * 
+	 * If multiple instances of metadata methods are invoked
+	 * (any combination of calls to metadataKey, metadataValue, or metadataPair),
+	 * then this query will return events which match ANY one of them.  
 	 */
 	public EventQuery metadataKey(String... metadataKey) {
 		if (this.metadataKeys == null) {
@@ -149,12 +149,12 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	}
 
 	/**
-	 * Add required metadata value to the query.
-	 * Returned events must include a metadata property with this value.
-	 * This method can accept multiple strings or be invoked multiple times
-	 * for the event to have multiple metadata values. Each time this is called it
-	 * adds another required value rather than replacing previous required values.
-	 */
+	 * Return events with metadata containing a property having the given value.
+	 * 
+	 * If multiple instances of metadata methods are invoked
+	 * (any combination of calls to metadataKey, metadataValue, or metadataPair),
+	 * then this query will return events which match ANY one of them.  
+ 	*/
 	public EventQuery metadataValue(String... metadataValue) {
 		if (this.metadataValues == null) {
 			this.metadataValues = new ArrayList<>();
@@ -164,11 +164,11 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	}
 
 	/**
-	 * Add a required metadata key/value pair to the query.
-	 * Returned events must include a metadata property with this key and value.
-	 * This method can be invoked multiple times to require the event to have multiple
-	 * metadata key value pairs.  Each time this is called it adds another required key value pair rather than
-	 * replacing previous required key value pairs.
+	 * Return events with metadata containing a property having the given key-value pair.
+	 * 
+	 * If multiple instances of metadata methods are invoked
+	 * (any combination of calls to metadataKey, metadataValue, or metadataPair),
+	 * then this query will return events which match ANY one of them.  
 	 */
 	public EventQuery metadataPair(String key, String value) {
 		if (this.metadataPairs == null) {


### PR DESCRIPTION
# Description
The Nylas Calendar API has a new beta feature of adding a new [metadata field to calendar events](https://www.nylas.com/blog/event-metadata). This PR makes the feature available via the Nylas Java SDK. 

# Usage
To create a new event with event metadata, you can create a `Map<String, String>` with a mapping of key-value pairs for the metadata:
```
Event event = new Event(calendarId, new Timespan(startTime, endTime));
....
Map<String, String> metadata = new HashMap<>();
metadata.put("event_category", "gathering");
event.setMetadata(metadata);
```

To query events based on metadata, you can filter on three different parameters:
- `metadata_key` (string or array) to filter based on the keys within the metadata object
- `metadata_value` (string or array) to filter based on the value within the metadata object
- `metadata_pair` (pair of strings; a key and a value) to filter based on the key-value pairs within the metadata object

You can invoke them as such and even chain them:
```
EventQuery query = new EventQuery()
                .calendarId(calendarId)
                .metadataKey("visitors", "parking")
                .metadataValue("garden")
                .metadataPair("event_category", "gathering");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.