### PR TITLE
 [51225] Support new `message.bounced` webhook trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This section contains changes that have been committed but not yet released.
 ### Added
 
 - Add `metadata` field in the Event model to support new event metadata
-- Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`]
+- Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`
+- Support new `message.bounced` webhook trigger
 
 ### Changed
 

--- a/src/examples/java/com/nylas/examples/webhooks/WebhooksExample.java
+++ b/src/examples/java/com/nylas/examples/webhooks/WebhooksExample.java
@@ -35,6 +35,7 @@ public class WebhooksExample {
 				"message.created",
 				"message.opened",
 				"message.link_clicked",
+				"message.bounced",
 				"thread.replied",
 				"contact.created",
 				"contact.updated",

--- a/src/main/java/com/nylas/Notification.java
+++ b/src/main/java/com/nylas/Notification.java
@@ -150,6 +150,13 @@ public class Notification {
 	public static class Attributes {
 		private String received_date;
 		private String thread_id;
+
+		// message.bounced specific fields
+		private String message_id;
+		private String original_message_id;
+		private String original_thread_id;
+		private String bounce_reason;
+		private String bounce_diagnostic;
 		
 		/**
 		 * A timestamp indicating when the message was originally received.
@@ -165,9 +172,46 @@ public class Notification {
 			return thread_id;
 		}
 
+		/**
+		 * The message ID of the bounce reply message
+		 */
+		public String getMessageId() {
+			return message_id;
+		}
+
+		/**
+		 * The message ID of the email that was actually bounced
+		 */
+		public String getOriginalMessageId() {
+			return original_message_id;
+		}
+
+		/**
+		 * The thread ID that the bounced message belonged to
+		 */
+		public String getOriginalThreadId() {
+			return original_thread_id;
+		}
+
+		/**
+		 * The reason for the bounce parsed directly from the bounce reply
+		 */
+		public String getBounceReason() {
+			return bounce_reason;
+		}
+
+		/**
+		 * The detailed error message parsed directly from the bounce reply
+		 */
+		public String getBounceDiagnostic() {
+			return bounce_diagnostic;
+		}
+
 		@Override
 		public String toString() {
-			return "Attributes [receivedDate=" + received_date + ", threadId=" + thread_id + "]";
+			return "Attributes [receivedDate=" + received_date + ", threadId=" + thread_id + ", messageId=" + message_id
+					+ ", originalMessageId=" + original_message_id + ", originalThreadId=" + original_thread_id
+					+ ", bounceReason=" + bounce_reason + ", bounceDiagnostic=" + bounce_diagnostic + "]";
 		}
 	}
 	


### PR DESCRIPTION
# Description
Support for the new webhook trigger for detecting when an email has bounced. The new attributes have been added to allow for proper parsing of the extended message object.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.