### PR TITLE
[65379] Dynamic conference link creation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+- Add support for automatic meeting details
+
 ### Changed
 
 ### Deprecated

--- a/src/examples/java/com/nylas/examples/other/EventsExample.java
+++ b/src/examples/java/com/nylas/examples/other/EventsExample.java
@@ -52,6 +52,7 @@ public class EventsExample {
 		}
 		
 		basicEventCrud(events, primary);
+		autocreateEvents(events, primary);
 		//overrideRecurringEvent(primary, events);
 		//fetchRoomResources(events);
 		
@@ -59,17 +60,7 @@ public class EventsExample {
 	}
 
 	protected static void basicEventCrud(Events events, Calendar primary) throws IOException, RequestFailedException {
-		ZoneId startTz = ZoneId.of("America/Los_Angeles");
-		ZoneId endTz = ZoneId.of("America/New_York");
-		ZonedDateTime startTime = ZonedDateTime.now(startTz);
-		ZonedDateTime endTime = startTime.plusHours(2).withZoneSameInstant(endTz);
-
-		Event event = new Event(primary.getId(), new Timespan(startTime, endTime));
-		event.setTitle("Surprise Party");
-		Participant partier = new Participant("hamilton@example.com");
-		partier.name("Alexander Hamilton");
-
-		Event created = events.create(event, true);
+		Event created = createBasicEvent(events, primary);
 		System.out.println("Created: " + created);
 		
 		Participant partier1 = new Participant("hmulligan@example.com");
@@ -81,12 +72,15 @@ public class EventsExample {
 		Participant partier3 = new Participant("lafayette@example.com");
 		partier3.name("Marquis de Lafayette");
 
+		ZoneId startTz = ZoneId.of("America/Los_Angeles");
+		ZonedDateTime startTime = ZonedDateTime.now(startTz);
+
 		created.setDescription("hopping good fun");
 		created.setWhen(new Time(startTime)); // this party never ends
 		created.setTitle("Nonsurprise Party");
 		created.setBusy(false);
 		created.setLocation("Lake Merritt");
-		created.setParticipants(Arrays.asList(partier, partier1, partier2, partier3));
+		created.setParticipants(Arrays.asList(created.getParticipants().get(0), partier1, partier2, partier3));
 		created.setRecurrence(new Recurrence(startTz.getId(), Arrays.asList("RRULE:FREQ=WEEKLY;BYDAY=TH")));
 
 		Map<String, String> metadata = new HashMap<>();
@@ -106,6 +100,22 @@ public class EventsExample {
 		Event updated = events.update(created, true);
 		System.out.println("Updated: " + updated);
 		
+		events.delete(created.getId(), true);
+		System.out.println("Deleted");
+	}
+
+	protected static void autocreateEvents(Events events, Calendar primary) throws IOException, RequestFailedException {
+		Event created = createBasicEvent(events, primary);
+
+		Event.Conferencing conferencing = new Event.Conferencing();
+		conferencing.setProvider("Zoom Meeting");
+		Event.Conferencing.Autocreate autocreate = new Event.Conferencing.Autocreate();
+		conferencing.setAutocreate(autocreate);
+		created.setConferencing(conferencing);
+
+		Event updated = events.update(created, true);
+		System.out.println("Updated: " + updated);
+
 		events.delete(created.getId(), true);
 		System.out.println("Deleted");
 	}
@@ -132,6 +142,22 @@ public class EventsExample {
 			eventToOverride = events.update(eventToOverride, false);
 			System.out.println("Overrode event instance:" + eventToOverride);
 		}
+	}
+
+	private static Event createBasicEvent(Events events, Calendar primary) throws IOException, RequestFailedException {
+		ZoneId startTz = ZoneId.of("America/Los_Angeles");
+		ZoneId endTz = ZoneId.of("America/New_York");
+		ZonedDateTime startTime = ZonedDateTime.now(startTz);
+		ZonedDateTime endTime = startTime.plusHours(2).withZoneSameInstant(endTz);
+
+		Event event = new Event(primary.getId(), new Timespan(startTime, endTime));
+		event.setTitle("Surprise Party");
+		Participant partier = new Participant("hamilton@example.com");
+		partier.name("Alexander Hamilton");
+
+		Event created = events.create(event, true);
+		System.out.println("Created: " + created);
+		return created;
 	}
 
 }

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -203,6 +203,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	public static class Conferencing {
 		private String provider;
 		private Details details;
+		private Autocreate autocreate;
 
 		/** For deserialization only */ public Conferencing() {}
 
@@ -222,9 +223,18 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			this.details = details;
 		}
 
+		public Autocreate getAutocreate() {
+			return autocreate;
+		}
+
+		public void setAutocreate(Autocreate autocreate) {
+			this.autocreate = autocreate;
+		}
+
 		@Override
 		public String toString() {
-			return "Conferencing [provider=" + provider + ", details=" + details + "]";
+			return String.format("Conferencing [provider=%s, details=%s, autocreate=%s]",
+					provider, details, autocreate);
 		}
 
 		public static class Details {
@@ -278,6 +288,23 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			public String toString() {
 				return String.format("Details [url=%s, password=%s, pin=%s, meeting_code=%s, phone=%s]",
 						url, password, pin, meeting_code, phone);
+			}
+		}
+
+		public static class Autocreate {
+			private Map<String, String> settings;
+
+			public Map<String, String> getSettings() {
+				return settings;
+			}
+
+			public void setSettings(Map<String, String> settings) {
+				this.settings = settings;
+			}
+
+			@Override
+			public String toString() {
+				return String.format("Autocreate [settings=%s]", settings);
 			}
 		}
 	}

--- a/src/main/java/com/nylas/Events.java
+++ b/src/main/java/com/nylas/Events.java
@@ -40,6 +40,11 @@ public class Events extends RestfulDAO<Event> {
 	}
 	
 	public Event create(Event event, boolean notifyParticipants) throws IOException, RequestFailedException {
+		if(event.getConferencing() != null
+				&& event.getConferencing().getAutocreate() != null
+				&& event.getConferencing().getDetails() != null) {
+			throw new IllegalArgumentException("Cannot set both 'details' and 'autocreate' in conferencing object.");
+		}
 		return super.create(event, getExtraQueryParams(notifyParticipants));
 	}
 	

--- a/src/main/java/com/nylas/Events.java
+++ b/src/main/java/com/nylas/Events.java
@@ -40,15 +40,12 @@ public class Events extends RestfulDAO<Event> {
 	}
 	
 	public Event create(Event event, boolean notifyParticipants) throws IOException, RequestFailedException {
-		if(event.getConferencing() != null
-				&& event.getConferencing().getAutocreate() != null
-				&& event.getConferencing().getDetails() != null) {
-			throw new IllegalArgumentException("Cannot set both 'details' and 'autocreate' in conferencing object.");
-		}
+		validateConferencing(event);
 		return super.create(event, getExtraQueryParams(notifyParticipants));
 	}
 	
 	public Event update(Event event, boolean notifyParticipants) throws IOException, RequestFailedException {
+		validateConferencing(event);
 		return super.update(event, getExtraQueryParams(notifyParticipants));
 	}
 	
@@ -81,6 +78,19 @@ public class Events extends RestfulDAO<Event> {
 		HttpUrl.Builder url = client.newUrlBuilder().addPathSegment("send-rsvp");
 		addQueryParams(url, getExtraQueryParams(notifyParticipants));
 		return client.executePost(authUser, url, params, modelClass);
+	}
+
+	/**
+	 * Checks that the conferencing field is valid
+	 * An Event cannot have both manual conferencing details
+	 * and a conference autocreate field.
+	 */
+	private void validateConferencing(Event event) {
+		if(event.getConferencing() != null
+				&& event.getConferencing().getAutocreate() != null
+				&& event.getConferencing().getDetails() != null) {
+			throw new IllegalArgumentException("Cannot set both 'details' and 'autocreate' in conferencing object.");
+		}
 	}
 	
 	private static final Map<String, String> NOTIFY_PARTICIPANTS_PARAMS


### PR DESCRIPTION
# Description
The Event API, in addition to support for manually-added conference details, supports auto generating conference details. If you have an integration authorized and enabled for your Nylas account you can provide an `autocreate` object instead of a `details` object to have the Nylas API autofill the conferencing details.

# Usage
To have Nylas autocreate the conference field for you, pass the `autocreate` object to the new event:
```java
public class NylasExamples {
  public static void postEventExample() throws IOException, RequestFailedException {
    NylasClient nylas = new NylasClient();
    NylasAccount account = nylas.account("{ACCESS_TOKEN}");
    // Create a new event object
    Event event = new Event("{CALENDAR_ID}", when);
    // Add conferencing details
    Event.Conferencing conferencing = new Event.Conferencing();
    conferencing.setProvider("Zoom Meeting");

    Event.Conferencing.Autocreate autocreate = new Event.Conferencing.Autocreate();
    conferencing.setAutocreate(autocreate)

    event.setConferencing(conferencing);
  }
}

```
A few notes and things to keep in mind:
* Only **one** of `details` or `autocreate` can be present, and we have implemented client-side checking to enforce this rule
* Autocreating conferencing data is an asynchronous operation on the server-side. The Event object returned will not have a conferencing field, but it should be available in a future get call once the conference is created on the backend. The initial Event object returned will have a `jobStatusId` value which can be used to check on the status of conference creation.
* The `settings` object within the `autocreate` object maps to the settings the Nylas API will send to the conference provider for the conference creation. For example with Zoom the settings object maps to Zoom's [Create a Meeting object](https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingcreate).

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.