### PR TITLE
remove charset from content-type for sending raw mime message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+- Workaround for Send Raw MIME where server gives an error when charset is specified
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Drafts.java
+++ b/src/main/java/com/nylas/Drafts.java
@@ -2,6 +2,7 @@ package com.nylas;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -113,7 +114,19 @@ public class Drafts extends RestfulDAO<Draft> {
 	 */
 	public Message sendRawMime(String mimeMessage) throws IOException, RequestFailedException {
 		HttpUrl.Builder url = getSendUrl();
-		RequestBody requestBody = RequestBody.create(MediaType.get("message/rfc822"), mimeMessage);
+		/*
+		 * The server has an issue where if the content-type has a charset, for example:
+		 *   Content-Type: message/rfc822; charset=utf-8
+		 *   
+		 * Then it responds with this error:
+		 *  {"message":"400 Bad Request: The browser (or proxy) sent a request that this server could not understand.",
+		 *  "type":"api_error"}
+		 * 
+		 * To workaround that, we pre-encode the text to utf-8. Otherwise, when OkHttp encodes to utf-8
+		 * it also sets the charset, which causes the server error above.
+		 */
+		byte[] messageBytes = mimeMessage.getBytes(StandardCharsets.UTF_8);
+		RequestBody requestBody = RequestBody.create(MediaType.get("message/rfc822"), messageBytes);
 		return client.executeRequestWithAuth(authUser, url, HttpMethod.POST, requestBody, Message.class);
 	}
 


### PR DESCRIPTION
# Description
The server has an issue where if the content-type has a charset, for example:
	Content-Type: message/rfc822; charset=utf-8
 
Then it responds with this error:
  {"message":"400 Bad Request: The browser (or proxy) sent a request that this server could not understand.", "type":"api_error"}

To workaround that, we pre-encode the text to utf-8. Otherwise, when OkHttp encodes to utf-8 it also sets the charset, which causes the server error above.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.