### PR TITLE
[69629] Component CRUD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This section contains changes that have been committed but not yet released.
 
 - Add support for automatic meeting details
 - Add support for Event notifications
+- Add support for Component CRUD
 
 ### Changed
 

--- a/src/examples/java/com/nylas/examples/other/ComponentsExample.java
+++ b/src/examples/java/com/nylas/examples/other/ComponentsExample.java
@@ -1,0 +1,35 @@
+package com.nylas.examples.other;
+
+import com.nylas.*;
+import com.nylas.examples.ExampleConf;
+
+public class ComponentsExample {
+
+	public static void main(String[] args) throws Exception {
+
+		ExampleConf conf = new ExampleConf();
+		NylasClient client = new NylasClient();
+		NylasApplication application = client.application(conf.get("nylas.client.id"), conf.get("nylas.client.secret"));
+		Components components = application.components();
+
+		Component component = new Component();
+		component.setName("Java Component Test");
+		component.setType("agenda");
+		component.setPublicAccountId("ACCOUNT_ID");
+		component.setAccessToken(conf.get("access.token"));
+		component = components.save(component);
+
+		RemoteCollection<Component> componentList = components.list();
+		for(Component comp : componentList) {
+			System.out.println(comp);
+		}
+
+		Component fetchedComponent = components.get(component.getId());
+		fetchedComponent.setName("Updated component name");
+		fetchedComponent.addAllowedDomains("www.nylas.com");
+		fetchedComponent.addSetting("Test", "yes");
+		components.save(fetchedComponent);
+
+		components.delete(fetchedComponent.getId());
+	}
+}

--- a/src/main/java/com/nylas/Component.java
+++ b/src/main/java/com/nylas/Component.java
@@ -1,0 +1,160 @@
+package com.nylas;
+
+import java.util.*;
+
+public class Component extends RestfulModel {
+
+	private String name;
+	private String type;
+	private String public_application_id;
+	private String public_token_id;
+	private String public_account_id;
+	private String access_token;
+	private Integer action;
+	private Boolean active;
+	private Date created_at;
+	private Date updated_at;
+	private Map<String, Object> settings;
+	private List<String> allowed_domains;
+
+	public String getName() {
+		return name;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public Integer getAction() {
+		return action;
+	}
+
+	public Boolean isActive() {
+		return active;
+	}
+
+	public String getPublicAccountId() {
+		return public_account_id;
+	}
+
+	public String getPublicTokenId() {
+		return public_token_id;
+	}
+
+	public String getPublicApplicationId() {
+		return public_application_id;
+	}
+
+	public String getAccessToken() {
+		return access_token;
+	}
+
+	public Date getCreatedAt() {
+		return created_at;
+	}
+
+	public Date getUpdatedAt() {
+		return updated_at;
+	}
+
+	public Map<String, Object> getSettings() {
+		return settings;
+	}
+
+	public List<String> getAllowedDomains() {
+		return allowed_domains;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public void setAction(Integer action) {
+		this.action = action;
+	}
+
+	public void setActive(Boolean active) {
+		this.active = active;
+	}
+
+	public void setPublicAccountId(String publicAccountId) {
+		this.public_account_id = publicAccountId;
+	}
+
+	public void setPublicTokenId(String publicTokenId) {
+		this.public_token_id = publicTokenId;
+	}
+
+	public void setPublicApplicationId(String publicApplicationId) {
+		this.public_application_id = publicApplicationId;
+	}
+
+	public void setAccessToken(String accessToken) {
+		this.access_token = accessToken;
+	}
+
+	public void setSettings(Map<String, Object> settings) {
+		this.settings = settings;
+	}
+
+	public void setAllowedDomains(List<String> allowedDomains) {
+		this.allowed_domains = allowedDomains;
+	}
+
+	public boolean addAllowedDomains(String... allowedDomains) {
+		if(this.allowed_domains == null) {
+			this.allowed_domains = new ArrayList<>();
+		}
+		return Collections.addAll(this.allowed_domains, allowedDomains);
+	}
+
+	public boolean addSetting(String settingName, Object settingValue) {
+		if(this.settings == null) {
+			this.settings = new HashMap<>();
+		}
+		this.settings.put(settingName, settingValue);
+		return true;
+	}
+
+	@Override
+	Map<String, Object> getWritableFields(boolean creation) {
+		Map<String, Object> params = new HashMap<>();
+
+		if(creation) {
+			Maps.putIfNotNull(params, "type", type);
+			Maps.putIfNotNull(params, "public_application_id", public_application_id);
+			Maps.putIfNotNull(params, "access_token", access_token);
+		}
+
+		Maps.putIfNotNull(params, "name", name);
+		Maps.putIfNotNull(params, "public_token_id", public_token_id);
+		Maps.putIfNotNull(params, "public_account_id", public_account_id);
+		Maps.putIfNotNull(params, "action", action);
+		Maps.putIfNotNull(params, "active", active);
+		Maps.putIfNotNull(params, "settings", settings);
+		Maps.putIfNotNull(params, "allowed_domains", allowed_domains);
+		return params;
+	}
+
+	@Override
+	public String toString() {
+		return "Component [" +
+				"name='" + name + '\'' +
+				", type='" + type + '\'' +
+				", public_application_id='" + public_application_id + '\'' +
+				", public_token_id='" + public_token_id + '\'' +
+				", public_account_id='" + public_account_id + '\'' +
+				", access_token='" + access_token + '\'' +
+				", action=" + action +
+				", active=" + active +
+				", created_at=" + created_at +
+				", updated_at=" + updated_at +
+				", settings=" + settings +
+				", allowed_domains=" + allowed_domains +
+				']';
+	}
+}

--- a/src/main/java/com/nylas/ComponentQuery.java
+++ b/src/main/java/com/nylas/ComponentQuery.java
@@ -1,0 +1,4 @@
+package com.nylas;
+
+public class ComponentQuery extends RestfulQuery<ComponentQuery> {
+}

--- a/src/main/java/com/nylas/Components.java
+++ b/src/main/java/com/nylas/Components.java
@@ -1,0 +1,48 @@
+package com.nylas;
+
+import java.io.IOException;
+
+public class Components extends RestfulDAO<Component> {
+
+	Components(NylasClient client, NylasApplication application) {
+		super(client, Component.class, "component/" + application.getClientId(), application.getClientSecret());
+	}
+
+	public RemoteCollection<Component> list() throws IOException, RequestFailedException {
+		return list(new ComponentQuery());
+	}
+
+	public RemoteCollection<Component> list(ComponentQuery query) throws IOException, RequestFailedException {
+		return super.list(query);
+	}
+
+	@Override
+	public Component get(String id) throws IOException, RequestFailedException {
+		return super.get(id);
+	}
+
+	public Component create(Component component) throws IOException, RequestFailedException {
+		return super.create(component);
+	}
+
+	public Component update(Component component) throws IOException, RequestFailedException {
+		return super.update(component);
+	}
+
+	/**
+	 * Delete the scheduler with the given id.
+	 * Returns the id of job status for the deletion.
+	 */
+	public String delete(String id) throws IOException, RequestFailedException {
+		return super.delete(id);
+	}
+
+	/**
+	 * Convenience method to create or update the given scheduler.
+	 * If it has an existing ID, update it, otherwise create it.
+	 * Returns the scheduler as returned by the server.
+	 */
+	public Component save(Component component) throws IOException, RequestFailedException {
+		return component.hasId() ? update(component) : create(component);
+	}
+}

--- a/src/main/java/com/nylas/JsonHelper.java
+++ b/src/main/java/com/nylas/JsonHelper.java
@@ -2,6 +2,7 @@ package com.nylas;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -9,6 +10,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
@@ -20,6 +22,7 @@ public class JsonHelper {
 		moshi = new Moshi.Builder()
 				.add(Event.WHEN_JSON_FACTORY)
 				.add(Event.EVENT_NOTIFICATION_JSON_FACTORY)
+				.add(Date.class, new Rfc3339DateJsonAdapter().nullSafe())
 				.build();
 	}
 	

--- a/src/main/java/com/nylas/NylasApplication.java
+++ b/src/main/java/com/nylas/NylasApplication.java
@@ -45,6 +45,10 @@ public class NylasApplication {
 	public Webhooks webhooks() {
 		return new Webhooks(client, this);
 	}
+
+	public Components components() {
+		return new Components(client, this);
+	}
 	
 	/**
 	 * Get the application details for this application


### PR DESCRIPTION
# Description
This PR enables SDK support for the Nylas `/component` endpoints.

# Usage
To create a new component:
```java
Component component = new Component();
component.setName("Java Component Test");
component.setType("agenda");
component.setPublicAccountId("ACCOUNT_ID");
component.setAccessToken(conf.get("access.token"));
component = application.components().save(component);
```

To get all components:
```java
RemoteCollection<Component> componentList = application.components().list();
```

To get a specific component:
```java
Component component = application.components().get("{COMPONENT_ID}");
```

To update a component:
```java
Component component = application.components().get("{COMPONENT_ID}");
component.name = "Updated"
application.components().save(component);
```

To delete a component:
```java
application.components().delete("{COMPONENT_ID}")
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.