### PR TITLE
[75380] Fix bug where updating an Event results in an API error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+- Fix bug where updating an event resulted in an API error
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
@@ -172,11 +173,19 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		if (creation) {
 			Maps.putIfNotNull(params, "calendar_id", getCalendarId());
 		}
+
+		List<Map<String, Object>> participantWritableFields = null;
+		if(!participants.isEmpty()) {
+			participantWritableFields = participants.stream()
+					.map(Participant::getWritableFields)
+					.collect(Collectors.toList());
+		}
+
 		Maps.putIfNotNull(params, "when", getWhen());
 		Maps.putIfNotNull(params, "title", getTitle());
 		Maps.putIfNotNull(params, "description", getDescription());
 		Maps.putIfNotNull(params, "location", getLocation());
-		Maps.putIfNotNull(params, "participants", getParticipants());
+		Maps.putIfNotNull(params, "participants", participantWritableFields);
 		Maps.putIfNotNull(params, "busy", getBusy());
 		Maps.putIfNotNull(params, "metadata", getMetadata());
 		Maps.putIfNotNull(params, "conferencing", getConferencing());

--- a/src/main/java/com/nylas/Participant.java
+++ b/src/main/java/com/nylas/Participant.java
@@ -1,5 +1,8 @@
 package com.nylas;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Participant {
 
 	private String name;
@@ -37,6 +40,7 @@ public class Participant {
 		return this;
 	}
 
+	@Deprecated
 	public Participant status(String status) {
 		this.status = status;
 		return this;
@@ -45,6 +49,14 @@ public class Participant {
 	public Participant comment(String comment) {
 		this.comment = comment;
 		return this;
+	}
+
+	Map<String, Object> getWritableFields() {
+		Map<String, Object> params = new HashMap<>();
+		Maps.putIfNotNull(params, "name", name);
+		Maps.putIfNotNull(params, "email", email);
+		Maps.putIfNotNull(params, "comment", comment);
+		return params;
 	}
 
 	@Override


### PR DESCRIPTION
# Description
A recent API update caused updating an event using the SDK to return an error because the SDK sends a Participant's status. This PR ensures that the Participant object omits it on outgoing API calls.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.