### PR TITLE
move to log4j 2.15.0 for tests and examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     
     // use log4j logging for tests
-    testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.12.1')
+    testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.15.0')
     
     // use wiremock for mocking the nylas server during tests
     testImplementation('com.github.tomakehurst:wiremock-jre8:2.26.3')
@@ -57,9 +57,9 @@ dependencies {
     // Examples dependencies
     
     // use log4j2 logging for examples
-    examplesImplementation('org.apache.logging.log4j:log4j-api:2.12.1')
-    examplesImplementation('org.apache.logging.log4j:log4j-core:2.12.1')
-    examplesImplementation('org.apache.logging.log4j:log4j-slf4j-impl:2.12.1')
+    examplesImplementation('org.apache.logging.log4j:log4j-api:2.15.0')
+    examplesImplementation('org.apache.logging.log4j:log4j-core:2.15.0')
+    examplesImplementation('org.apache.logging.log4j:log4j-slf4j-impl:2.15.0')
     
     // Guava for examples since it makes all Java better and we don't need to worry about
     // conflicting dependencies downstream for examples


### PR DESCRIPTION
There was a major log4j vulnerability recently announced and patched.  The Nylas Java SDK only uses log4j for tests and examples, so clients should not be affected, but it should still update.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.