### PR TITLE
Update `log4j` to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Security
 
+- Address major `log4j` vulnerability, updated `log4j` to v2.17.0
+
 ## [1.10.1] - Released 2021-12-13
 
 ### Security

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
     
     // use log4j logging for tests
-    testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.15.0')
+    testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.17.0')
     
     // use wiremock for mocking the nylas server during tests
     testImplementation('com.github.tomakehurst:wiremock-jre8:2.26.3')
@@ -57,9 +57,9 @@ dependencies {
     // Examples dependencies
     
     // use log4j2 logging for examples
-    examplesImplementation('org.apache.logging.log4j:log4j-api:2.15.0')
-    examplesImplementation('org.apache.logging.log4j:log4j-core:2.15.0')
-    examplesImplementation('org.apache.logging.log4j:log4j-slf4j-impl:2.15.0')
+    examplesImplementation('org.apache.logging.log4j:log4j-api:2.17.0')
+    examplesImplementation('org.apache.logging.log4j:log4j-core:2.17.0')
+    examplesImplementation('org.apache.logging.log4j:log4j-slf4j-impl:2.17.0')
     
     // Guava for examples since it makes all Java better and we don't need to worry about
     // conflicting dependencies downstream for examples


### PR DESCRIPTION
# Description
There have been 2 new vulnerabilities found in `log4j` since we updated the dependency to `2.15.0`. The SDK's use of the log4j is limited to just testing and example code, but better to be safe than to take the risk.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.