### PR TITLE
v1.10.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## [1.10.2] - Released 2021-12-23
 
 ### Changed
@@ -170,6 +186,7 @@ fetching all via fetchAll method
 
 Initial preview release
 
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.10.2...HEAD
 [1.10.2]: https://github.com/nylas/nylas-java/releases/tag/v1.10.2
 [1.10.1]: https://github.com/nylas/nylas-java/releases/tag/v1.10.1
 [1.10.0]: https://github.com/nylas/nylas-java/releases/tag/v1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,10 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
-
-### Added
+## [1.10.2] - Released 2021-12-23
 
 ### Changed
 
 - Added `false` parameter when `notifyParticipants` is false
-
-### Deprecated
-
-### Fixed
-
-### Removed
 
 ### Security
 
@@ -180,7 +170,7 @@ fetching all via fetchAll method
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.10.1...HEAD
+[1.10.2]: https://github.com/nylas/nylas-java/releases/tag/v1.10.2
 [1.10.1]: https://github.com/nylas/nylas-java/releases/tag/v1.10.1
 [1.10.0]: https://github.com/nylas/nylas-java/releases/tag/v1.10.0
 [1.9.1]: https://github.com/nylas/nylas-java/releases/tag/v1.9.1

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.10.1")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.10.2")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.10.1</version>
+      <version>1.10.2</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.10.2
+version=1.11.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.11.0-SNAPSHOT
+version=1.10.2
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New `nylas` v1.10.2 release bringing in a minor change and a security update:
* Added `false` parameter when `notifyParticipants` is false (#34)
* Address major `log4j` vulnerability, updated `log4j` to v2.17.0 (#35)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.