### PR TITLE
[77019][77024] Hosted Authentication Imporovments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+- Added support for the `forced_password` Hosted Auth setting
+
 ### Changed
+
+- Added missing `EMAIL` scope
 
 ### Deprecated
 

--- a/src/examples/java/com/nylas/examples/hostedAuth/HostedAuthUrlExample.java
+++ b/src/examples/java/com/nylas/examples/hostedAuth/HostedAuthUrlExample.java
@@ -19,6 +19,7 @@ public class HostedAuthUrlExample {
 			.scopes(Scope.values())
 			.loginHint(conf.get("hosted.login.hint"))
 			.state("example_csrf_token")
+			.forcePassword(true)
 			.buildUrl();
 		
 		System.out.println("Forward the user to this URL for hosted authentication:");

--- a/src/main/java/com/nylas/HostedAuthentication.java
+++ b/src/main/java/com/nylas/HostedAuthentication.java
@@ -62,6 +62,7 @@ public class HostedAuthentication {
 		private String scopes = "";
 		private String loginHint = "";
 		private String state = "";
+		private Boolean forcePassword;
 
 		UrlBuilder(NylasApplication app) {
 			this.app = app;
@@ -130,6 +131,15 @@ public class HostedAuthentication {
 			this.state = state;
 			return this;
 		}
+
+		/**
+		 * An optional setting for when using a password or wanting to choose a different
+		 * provider than auto selected
+		 */
+		public UrlBuilder forcePassword(boolean forcePassword) {
+			this.forcePassword = forcePassword;
+			return this;
+		}
 		
 		private void validate() {
 			assertState(!nullOrEmpty(redirectUri), "Redirection URI is required");
@@ -156,6 +166,9 @@ public class HostedAuthentication {
 			}
 			if (!nullOrEmpty(state)) {
 				urlBuilder.addQueryParameter("state", state);
+			}
+			if (forcePassword != null) {
+				urlBuilder.addQueryParameter("force_password", String.valueOf(forcePassword));
 			}
 					
 			return urlBuilder.build().toString();

--- a/src/main/java/com/nylas/HostedAuthentication.java
+++ b/src/main/java/com/nylas/HostedAuthentication.java
@@ -62,7 +62,7 @@ public class HostedAuthentication {
 		private String scopes = "";
 		private String loginHint = "";
 		private String state = "";
-		private Boolean forcePassword;
+		private boolean forcePassword = false;
 
 		UrlBuilder(NylasApplication app) {
 			this.app = app;
@@ -167,8 +167,8 @@ public class HostedAuthentication {
 			if (!nullOrEmpty(state)) {
 				urlBuilder.addQueryParameter("state", state);
 			}
-			if (forcePassword != null) {
-				urlBuilder.addQueryParameter("force_password", String.valueOf(forcePassword));
+			if (forcePassword) {
+				urlBuilder.addQueryParameter("force_password", "true");
 			}
 					
 			return urlBuilder.build().toString();

--- a/src/main/java/com/nylas/Scope.java
+++ b/src/main/java/com/nylas/Scope.java
@@ -8,6 +8,11 @@ package com.nylas;
 public enum Scope {
 
 	/**
+	 * Read, modify, and send all messages, threads, file attachments, and read email metadata like headers.
+	 */
+	EMAIL("email"),
+
+	/**
 	 * Read and modify all messages, threads, file attachments, and read email metadata like headers.
 	 * Does not include send.
 	 */


### PR DESCRIPTION
# Description
This PR provides two minor improvements to Hosted Authentication.
1. Added in the missing `email` authentication scope
2. Added support for `force_password` setting during hosted authentication

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.