### PR TITLE
[76725] Add null checking to event participants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+- Fixed bug where saving an event without participants threw a `NullPointerException`
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
 
+import static com.nylas.Validations.nullOrEmpty;
+
 public class Event extends AccountOwnedModel implements JsonObject {
 
 	private String calendar_id;
@@ -175,7 +177,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		}
 
 		List<Map<String, Object>> participantWritableFields = null;
-		if(!participants.isEmpty()) {
+		if(!nullOrEmpty(participants)) {
 			participantWritableFields = participants.stream()
 					.map(Participant::getWritableFields)
 					.collect(Collectors.toList());

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -165,6 +165,37 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		this.recurrence = recurrence;
 	}
 
+	/**
+	 * Add single metadata key-value pair to the event
+	 * @param key The key of the metadata entry
+	 * @param value The value of the metadata entry
+	 */
+	public void addMetadata(String key, String value) {
+		if(metadata == null) {
+			metadata = new HashMap<>();
+		}
+		metadata.put(key, value);
+	}
+
+	/**
+	 * Add one (or many) notifications to the event
+	 * @param notifications The notification(s) to append to the event's notification list
+	 */
+	public void addNotification(Notification... notifications) {
+		if(this.notifications == null) {
+			this.notifications = new ArrayList<>();
+		}
+		this.notifications.addAll(Arrays.asList(notifications));
+	}
+
+	/**
+	 * Add one (or many) participants to the event
+	 * @param participants The participant(s) to append to the event's participant list
+	 */
+	public void addParticipants(Participant... participants) {
+		this.participants.addAll(Arrays.asList(participants));
+	}
+
 	@Override
 	Map<String, Object> getWritableFields(boolean creation) {
 		Map<String, Object> params = new HashMap<>();

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -4,15 +4,11 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
-
-import static com.nylas.Validations.nullOrEmpty;
 
 public class Event extends AccountOwnedModel implements JsonObject {
 
@@ -23,13 +19,13 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	private When when;
 	private String location;
 	private String owner;
-	private List<Participant> participants;
 	private String status;
 	private Boolean read_only;
 	private Boolean busy;
 	private Map<String, String> metadata;
 	private Conferencing conferencing;
 	private List<Notification> notifications;
+	private List<Participant> participants = new ArrayList<>();
 	
 	private Recurrence recurrence;
 	
@@ -177,7 +173,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		}
 
 		List<Map<String, Object>> participantWritableFields = null;
-		if(!nullOrEmpty(participants)) {
+		if(!participants.isEmpty()) {
 			participantWritableFields = participants.stream()
 					.map(Participant::getWritableFields)
 					.collect(Collectors.toList());

--- a/src/main/java/com/nylas/Validations.java
+++ b/src/main/java/com/nylas/Validations.java
@@ -1,5 +1,7 @@
 package com.nylas;
 
+import java.util.List;
+
 class Validations {
 
 	static void assertState(boolean valid, String message) {
@@ -28,6 +30,10 @@ class Validations {
 
 	static boolean nullOrEmpty(String s) {
 		return s == null || s.isEmpty();
+	}
+
+	static boolean nullOrEmpty(List<?> l) {
+		return l == null || l.isEmpty();
 	}
 	
 }


### PR DESCRIPTION
# Description
Saving an event without participants set would throw null because we checked if the list was empty without checking if it was null first.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.