### PR TITLE
[76797] Add support for modifying `Folder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,28 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
-- Added support for the `forced_password` Hosted Auth setting
+- Add support for modifying `Folder`
 
 ### Changed
-
-- Added missing `EMAIL` scope
 
 ### Deprecated
 
 ### Fixed
 
-- Fixed bug where saving an event without participants threw a `NullPointerException`
-
 ### Removed
 
 ### Security
+
+## [1.10.3] - Released 2022-01-05
+
+### Added
+
+- Added support for the `forced_password` Hosted Auth setting
+- Added missing `EMAIL` scope
+
+### Fixed
+
+- Fixed bug where saving an event without participants threw a `NullPointerException`
 
 ## [1.10.2] - Released 2021-12-23
 
@@ -64,7 +71,7 @@ This section contains changes that have been committed but not yet released.
 
 ### Deprecated
 
- - MicrosoftExchangeProviderSettings easServerHost in favor of exchangeServerHost
+- MicrosoftExchangeProviderSettings easServerHost in favor of exchangeServerHost
 
 ## [1.8.0] - Released 2021-07-30
 
@@ -82,11 +89,11 @@ This section contains changes that have been committed but not yet released.
 ### Added
 
 - Calendar.isPrimary field is now available
-- Event timezones will be checked for valid IANA zone names when created with ZonedDateTime objects 
+- Event timezones will be checked for valid IANA zone names when created with ZonedDateTime objects
 
 ### Deprecated
 
-- Deprecated Threads.setLabelIds method that takes an Iterable in favor for a Collection 
+- Deprecated Threads.setLabelIds method that takes an Iterable in favor for a Collection
 
 ### Fixed
 
@@ -102,7 +109,7 @@ This section contains changes that have been committed but not yet released.
 ### Deprecated
 
 - Deprecated `RequestFailedException` methods `getResponseBody` and `getStatus`
-in favor of `getStatusCode`, `getErrorType` and `getErrorMessage`
+  in favor of `getStatusCode`, `getErrorType` and `getErrorMessage`
 
 ## [1.5.0] - Released 2021-02-25
 
@@ -113,7 +120,7 @@ in favor of `getStatusCode`, `getErrorType` and `getErrorMessage`
 ### Deprecated
 
 - Deprecated public use of `RestfulQuery` methods `addParameters` and `copyAtNewOffsetLimit`.
-They are for internal use only and will be removed from the public API in the future.
+  They are for internal use only and will be removed from the public API in the future.
 
 ## [1.4.0] - Released 2020-12-11
 
@@ -121,8 +128,8 @@ They are for internal use only and will be removed from the public API in the fu
 
 - Calendar create, update, and delete support.
 - Job status support.  Many objects returned by the server from create and update operations will now include a job
-status id which can be used to track the status of syncing those changes back to the provider.  Similarly, delete
-operations will directly return job status ids.
+  status id which can be used to track the status of syncing those changes back to the provider.  Similarly, delete
+  operations will directly return job status ids.
 
 ### Fixed
 
@@ -165,7 +172,7 @@ Release 1.0.0 after users have been using it successfully.
 
 ### Changed
 
- - [BREAKING] Moved AuthenticationUrlBuilder to nested class HostedAuthentication.UrlBuilder
+- [BREAKING] Moved AuthenticationUrlBuilder to nested class HostedAuthentication.UrlBuilder
 
 ## [0.2.0] - Released 2020-04-27
 
@@ -179,8 +186,8 @@ This second release aims toward API stability so that we can get to v1.0.0.
 ### Changed
 
 - [BREAKING] List/query methods now return objects of type com.nylas.RemoteCollection (instead of java.util.List)
-which support lazy iteration of results fetched from the server in batches of 100 (by default), or eagerly
-fetching all via fetchAll method
+  which support lazy iteration of results fetched from the server in batches of 100 (by default), or eagerly
+  fetching all via fetchAll method
 - [BREAKING] Updated timestamp/date apis to use standard java.time.Instant and java.time.LocalDate
 - Other minor fixes
 
@@ -192,7 +199,8 @@ fetching all via fetchAll method
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.10.2...HEAD
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.10.3...HEAD
+[1.10.3]: https://github.com/nylas/nylas-java/releases/tag/v1.10.3
 [1.10.2]: https://github.com/nylas/nylas-java/releases/tag/v1.10.2
 [1.10.1]: https://github.com/nylas/nylas-java/releases/tag/v1.10.1
 [1.10.0]: https://github.com/nylas/nylas-java/releases/tag/v1.10.0

--- a/src/examples/java/com/nylas/examples/other/FoldersExample.java
+++ b/src/examples/java/com/nylas/examples/other/FoldersExample.java
@@ -35,9 +35,12 @@ public class FoldersExample {
 				inbox = folder;
 			}
 		}
-		
+
 		Folder newFolder = folders.create("Example Folder 7");
 		System.out.println(newFolder);
+		newFolder.setDisplayName("My Renamed Folder");
+		Folder updatedFolder = folders.update(newFolder);
+		System.out.println(updatedFolder);
 		
 		Threads threads = account.threads();
 		List<Thread> threadList = threads.list(new ThreadQuery().limit(1)).fetchAll();
@@ -48,11 +51,11 @@ public class FoldersExample {
 		
 		String threadId = threadList.get(0).getId();
 		
-		Thread thread = threads.setFolderId(threadId, newFolder.getId());
+		Thread thread = threads.setFolderId(threadId, updatedFolder.getId());
 		System.out.println(thread);
 		
 		try {
-			folders.delete(newFolder.getId());
+			folders.delete(updatedFolder.getId());
 		} catch (RequestFailedException rfe) {
 			System.out.println(rfe.getErrorMessage());
 		}
@@ -61,6 +64,6 @@ public class FoldersExample {
 		thread = threads.setFolderId(threadId, inbox.getId());
 		System.out.println(thread);
 		
-		folders.delete(newFolder.getId());
+		folders.delete(updatedFolder.getId());
 	}
 }

--- a/src/main/java/com/nylas/Folder.java
+++ b/src/main/java/com/nylas/Folder.java
@@ -1,5 +1,8 @@
 package com.nylas;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Folder extends AccountOwnedModel implements JsonObject {
 
 	private String name;
@@ -16,6 +19,22 @@ public class Folder extends AccountOwnedModel implements JsonObject {
 
 	public String getDisplayName() {
 		return display_name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setDisplayName(String displayName) {
+		this.display_name = displayName;
+	}
+
+	@Override
+	Map<String, Object> getWritableFields(boolean creation) {
+		Map<String, Object> params = new HashMap<>();
+		Maps.putIfNotNull(params, "name", getName());
+		Maps.putIfNotNull(params, "display_name", getDisplayName());
+		return params;
 	}
 
 	@Override

--- a/src/main/java/com/nylas/Folders.java
+++ b/src/main/java/com/nylas/Folders.java
@@ -36,6 +36,11 @@ public class Folders extends RestfulDAO<Folder> {
 	public String delete(String folderId) throws IOException, RequestFailedException {
 		return super.delete(folderId);
 	}
+
+	@Override
+	public Folder update(Folder folder) throws RequestFailedException, IOException {
+		return super.update(folder);
+	}
 	
 	/**
 	 * Change the display name of the given folder.


### PR DESCRIPTION
# Description
This PR enables support for modifying a Folder

# Usage
```java
NylasClient nylas = new NylasClient();
NylasAccount account = nylas.account("{ACCESS_TOKEN}");
Folders folders = account.folders();
Folder folder = folders.get("{folderId}");

folder.setDisplayName("Updated name");
folder.setName("sent");

Folder updated = folders.update(folder);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.