### PR TITLE
Add metadata field for message

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.11.0-SNAPSHOT
+version=1.11.1-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/src/main/java/com/nylas/Draft.java
+++ b/src/main/java/com/nylas/Draft.java
@@ -134,6 +134,11 @@ public class Draft extends Message {
 		this.thread_id = threadId;
 	}
 
+
+	public void setMetadata(Map<String, Object> metadata) {
+		this.metadata=metadata;
+	}
+
 	@Override
 	protected Map<String, Object> getWritableFields(boolean creation) {
 		Map<String, Object> params = new HashMap<>();
@@ -145,6 +150,7 @@ public class Draft extends Message {
 		Maps.putIfNotNull(params, "bcc", getBcc());
 		Maps.putIfNotNull(params, "body", getBody());
 		Maps.putIfNotNull(params, "version", getVersion());
+		Maps.putIfNotNull(params, "metadata", getMetadata());
 		List<String> fileIds = getFiles().stream().map(f -> f.getId()).collect(Collectors.toList());
 		params.put("file_ids", fileIds);
 		

--- a/src/main/java/com/nylas/Message.java
+++ b/src/main/java/com/nylas/Message.java
@@ -28,6 +28,8 @@ public class Message extends AccountOwnedModel implements JsonObject {
 	// only available in expanded message view
 	private Map<String, Object> headers = Collections.emptyMap();
 
+	protected Map<String,Object> metadata = Collections.emptyMap();
+
 	@Override
 	public String getObjectType() {
 		return "message";
@@ -104,6 +106,10 @@ public class Message extends AccountOwnedModel implements JsonObject {
 		return headers;
 	}
 
+
+	public Map<String, Object> getMetadata() {
+		return metadata;
+	}
 	@Override
 	public String toString() {
 		return "Message [id=" + getId() + ", account_id=" + getAccountId() + ", thread_id=" + thread_id + ", subject="


### PR DESCRIPTION
# Description
This PR In order to support metadata in SDK when sending draft/message

# Usage
```
val draft = Draft()
        draft.setFrom(NameEmail("","XXX@gmail.com"))
        draft.to= listOf(
            NameEmail("","YYY@gmail.com")
        )
        draft.subject = "test subject"
        draft.body = "test body"
        draft.metadata = mapOf(
            "testkey" to "testvalue",
            "testkey2" to "testvalue2"
        )

        val message = nylasAccount.drafts().send(draft)
```
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.