### PR TITLE
Fix cannot put metadata

### DIFF
--- a/src/main/java/com/nylas/Draft.java
+++ b/src/main/java/com/nylas/Draft.java
@@ -105,7 +105,12 @@ public class Draft extends Message {
 	public void setFiles(List<File> files) {
 		this.files = files;
 	}
-	
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
 	public void attach(File file) {
 		this.files.add(file);
 	}


### PR DESCRIPTION
# Description
This PR In order to fix a bug.
    currently, Although `metadata` field exists in the `Message`
    But another [commit]( https://github.com/nylas/nylas-java/commit/f7c80fd8a4819bdff4874f31ed1cbd5fb0acd94f#diff-0d5e93c03fd6f9c73b53db147e4e39a8d9ae0f27b48c43151adb9433d3b10a73)  add `metadata` in Draft, But it does not add a getter for that `metadata`.
   So, still  get empty `metadata` after putting `metadata`
   
  BTW,  if the PR does any issues here, please approval it and release a new sdk version, it is very urgent for us, Thanks 🙏

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.