### PR TITLE
Remove `metadata` field from `Draft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+- Fixed bug where an `IllegalArgumentException` is thrown when deserializing `Draft` with `metadata`
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Draft.java
+++ b/src/main/java/com/nylas/Draft.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 public class Draft extends Message {
 
-	protected Map<String, String> metadata = new HashMap<>() ;
 	private String reply_to_message_id;
 	private Integer version;
 	private Tracking tracking;

--- a/src/main/java/com/nylas/Message.java
+++ b/src/main/java/com/nylas/Message.java
@@ -1,10 +1,7 @@
 package com.nylas;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Message extends AccountOwnedModel implements JsonObject {
 
@@ -24,7 +21,7 @@ public class Message extends AccountOwnedModel implements JsonObject {
 	protected List<Event> events = Collections.emptyList();
 	protected Folder folder;
 	protected List<Label> labels = Collections.emptyList();
-	protected Map<String, String> metadata = Collections.emptyMap();
+	protected Map<String, String> metadata = new HashMap<>();
 
 	// only available in expanded message view
 	private Map<String, Object> headers = Collections.emptyMap();


### PR DESCRIPTION
# Description
Having an overriding field in `Draft` causes `getMetadata()` to return an empty map and it causes Java to throw a runtime error when deserializing a `Draft` object.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.