### PR TITLE
v1.11.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,10 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
-
-### Added
-
-### Changed
-
-### Deprecated
+## [1.11.1] - Released 2022-01-24
 
 ### Fixed
 
 - Fixed bug where an `IllegalArgumentException` is thrown when deserializing `Draft` with `metadata`
-
-### Removed
-
-### Security
 
 ## [1.11.0] - Released 2022-01-20
 
@@ -209,7 +197,7 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.11.0...HEAD
+[1.11.1]: https://github.com/nylas/nylas-java/compare/v1.11.1
 [1.11.0]: https://github.com/nylas/nylas-java/releases/tag/v1.11.0
 [1.10.3]: https://github.com/nylas/nylas-java/releases/tag/v1.10.3
 [1.10.2]: https://github.com/nylas/nylas-java/releases/tag/v1.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## [1.11.1] - Released 2022-01-24
 
 ### Fixed
@@ -197,7 +213,8 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[1.11.1]: https://github.com/nylas/nylas-java/compare/v1.11.1
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/nylas/nylas-java/releases/tag/v1.11.1
 [1.11.0]: https://github.com/nylas/nylas-java/releases/tag/v1.11.0
 [1.10.3]: https://github.com/nylas/nylas-java/releases/tag/v1.10.3
 [1.10.2]: https://github.com/nylas/nylas-java/releases/tag/v1.10.2

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.11.0")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.11.1")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.11.0</version>
+      <version>1.11.1</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.12.0-SNAPSHOT
+version=1.11.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.11.1
+version=1.12.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New `nylas` v1.11.1 release bringing in a minor fix:
* Fixed bug where an `IllegalArgumentException` is thrown when deserializing `Draft` with `metadata (#46).

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.