### PR TITLE
[79626] Remove use of `okhttp3.internal` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Removed
 
+- Remove use of `okhttp3.internal` library
+
 ### Security
 
 ## [1.11.1] - Released 2022-01-24

--- a/src/main/java/com/nylas/NylasClient.java
+++ b/src/main/java/com/nylas/NylasClient.java
@@ -16,7 +16,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okhttp3.internal.Util;
 
 /**
  * The NylasClient is the entry point to the Java SDK's API.
@@ -120,7 +119,7 @@ public class NylasClient {
 	
 	<T> T executePost(String authUser, HttpUrl.Builder url, Map<String, Object> params, Type resultType)
 			throws IOException, RequestFailedException {
-		RequestBody jsonBody = Util.EMPTY_REQUEST;
+		RequestBody jsonBody = RequestBody.create(null, new byte[0]);;
 		if (params != null) {
 			jsonBody = JsonHelper.jsonRequestBody(params);
 		}


### PR DESCRIPTION
# Description
This package is not meant to be used by us. Using this package can cause dependency issues in apps that use our SDK.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.