### PR TITLE
[TSDK-236] Support new `calendars` field in free-busy/availability queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This section contains changes that have been committed but not yet released.
 - Added Outbox support
 - Added support for Component CRUD
 - Added support for Neural Categorizer
+- Added support for `calendar` field in free-busy, availability, and consecutive availability queries
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Deprecated
 
+- Deprecated `checkFreeBusy(Instant, Instant, List<String>)` and `checkFreeBusy(Instant, Instant, String)` in favour of `checkFreeBusy(FreeBusyQuery)`
+
 ### Fixed
 
 ### Removed

--- a/src/examples/java/com/nylas/examples/other/CalendarsExample.java
+++ b/src/examples/java/com/nylas/examples/other/CalendarsExample.java
@@ -78,9 +78,7 @@ public class CalendarsExample {
 
 	protected static void availability(Calendars calendars, String accountId, String calendarId, String email)
 			throws RequestFailedException, IOException {
-		FreeBusyCalendars freeBusyCalendars = new FreeBusyCalendars();
-		freeBusyCalendars.setAccountId(accountId);
-		freeBusyCalendars.addCalendarIds(calendarId);
+		FreeBusyCalendars freeBusyCalendars = new FreeBusyCalendars(accountId, Collections.singletonList(calendarId));
 		SingleAvailabilityQuery query = new SingleAvailabilityQuery()
 				.durationMinutes(30)
 				.startTime(Instant.now())

--- a/src/examples/java/com/nylas/examples/other/CalendarsExample.java
+++ b/src/examples/java/com/nylas/examples/other/CalendarsExample.java
@@ -37,43 +37,28 @@ public class CalendarsExample {
 		if (calendarEmail == null) {
 			log.info("No calendar found with a name that looks like an email");
 		} else {
-			Instant end = ZonedDateTime.now().toInstant();
-			Instant start = end.minus(30, ChronoUnit.DAYS);
-			FreeBusyQuery query = new FreeBusyQuery()
-					.startTime(start.getEpochSecond())
-					.endTime(end.getEpochSecond())
-					.emails(calendarEmail);
-			List<FreeBusy> freeBusyInfo = calendars.checkFreeBusy(query);
-			for (FreeBusy freeBusy : freeBusyInfo) {
-				log.info(freeBusy);
-			}
+			log.info("Checking Free/Busy for the next 30 days");
+			checkFreeBusy(calendars, calendarEmail);
+
+			log.info("Checking availability for the next hour");
+			availability(calendars, accountId, calendarId, calendarEmail);
 		}
-		
-		Calendar newCal = new Calendar();
-		newCal.setName("New Test Calendar");
-		newCal.setDescription("Testing calendar creation");
-		newCal.setLocation("far, far away");
-		newCal.setTimezone("America/Los_Angeles");
-		Calendar created = calendars.create(newCal);
-		log.info("Created: " + created + " status: " + created.getJobStatusId());
 
-		created.setName("New Test Calendar (changed)");
-		created.setDescription("this calendar has been updated!");
-		created.setLocation("nearby");
-		created.setTimezone("America/New_York");
-		Map<String, String> metadata = new HashMap<>();
-		metadata.put("calendar_type", "test");
-		created.setMetadata(metadata);
-		Calendar updated = calendars.update(created);
-		log.info("Updated: " + updated + " status: " + updated.getJobStatusId());
+		log.info("Creating a new calendar");
+		createCalendar(account);
+	}
 
-		String deleteJobStatusId = calendars.delete(updated.getId());
-		log.info("Deleted, deleted job status id: " + deleteJobStatusId);
-
-		JobStatus deleteStatus = account.jobStatuses().get(deleteJobStatusId);
-		log.info("Deletion status: " + deleteStatus);
-
-		availability(calendars, accountId, calendarId, calendarEmail);
+	protected static void checkFreeBusy(Calendars calendars, String email) throws RequestFailedException, IOException {
+		Instant end = ZonedDateTime.now().toInstant();
+		Instant start = end.minus(30, ChronoUnit.DAYS);
+		FreeBusyQuery query = new FreeBusyQuery()
+				.startTime(start.getEpochSecond())
+				.endTime(end.getEpochSecond())
+				.emails(email);
+		List<FreeBusy> freeBusyInfo = calendars.checkFreeBusy(query);
+		for (FreeBusy freeBusy : freeBusyInfo) {
+			log.info(freeBusy);
+		}
 	}
 
 	protected static void availability(Calendars calendars, String accountId, String calendarId, String email)
@@ -98,5 +83,32 @@ public class CalendarsExample {
 
 		List<List<ConsecutiveAvailability>> consecutiveAvailability = calendars.consecutiveAvailability(consecutiveQuery);
 		log.info(consecutiveAvailability.toString());
+	}
+
+	protected static void createCalendar(NylasAccount account) throws RequestFailedException, IOException {
+		Calendars calendars = account.calendars();
+		Calendar newCal = new Calendar();
+		newCal.setName("New Test Calendar");
+		newCal.setDescription("Testing calendar creation");
+		newCal.setLocation("far, far away");
+		newCal.setTimezone("America/Los_Angeles");
+		Calendar created = calendars.create(newCal);
+		log.info("Created: " + created + " status: " + created.getJobStatusId());
+
+		created.setName("New Test Calendar (changed)");
+		created.setDescription("this calendar has been updated!");
+		created.setLocation("nearby");
+		created.setTimezone("America/New_York");
+		Map<String, String> metadata = new HashMap<>();
+		metadata.put("calendar_type", "test");
+		created.setMetadata(metadata);
+		Calendar updated = calendars.update(created);
+		log.info("Updated: " + updated + " status: " + updated.getJobStatusId());
+
+		String deleteJobStatusId = calendars.delete(updated.getId());
+		log.info("Deleted, deleted job status id: " + deleteJobStatusId);
+
+		JobStatus deleteStatus = account.jobStatuses().get(deleteJobStatusId);
+		log.info("Deletion status: " + deleteStatus);
 	}
 }

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -15,61 +15,98 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 	private List<OpenHours> openHours;
 	protected List<FreeBusyCalendars> calendars;
 
+	/**
+	 * The total number of minutes the event should last
+	 */
 	public Q durationMinutes(int durationMinutes) {
 		this.durationMinutes = durationMinutes;
 		return self();
 	}
 
+	/**
+	 * How many minutes it should check for availability
+	 */
 	public Q intervalMinutes(int intervalMinutes) {
 		this.intervalMinutes = intervalMinutes;
 		return self();
 	}
 
+	/**
+	 * The amount of buffer time in minutes that you want around existing meetings
+	 */
 	public Q buffer(int buffer) {
 		this.buffer = buffer;
 		return self();
 	}
 
+	/**
+	 * Availability of EWS calendars for tentative events
+	 */
 	public Q tentativeBusy(boolean tentativeBusy) {
 		this.tentativeBusy = tentativeBusy;
 		return self();
 	}
 
+	/**
+	 * The timestamp for the beginning of the event
+	 */
 	public Q startTime(Instant startTime) {
 		this.startTime = startTime.getEpochSecond();
 		return self();
 	}
 
+	/**
+	 * The timestamp for the beginning of the event
+	 */
 	public Q startTime(Long startTime) {
 		this.startTime = startTime;
 		return self();
 	}
 
+	/**
+	 * The timestamp for the end of the event
+	 */
 	public Q endTime(Instant endTime) {
 		this.endTime = endTime.getEpochSecond();
 		return self();
 	}
 
+	/**
+	 * The timestamp for the end of the event
+	 */
 	public Q endTime(Long endTime) {
 		this.endTime = endTime;
 		return self();
 	}
 
+	/**
+	 * A list of {@link FreeBusy} data for users not in your organization
+	 */
 	public Q freeBusy(List<FreeBusy> freeBusy) {
 		this.freeBusy = freeBusy;
 		return self();
 	}
 
+	/**
+	 * Additional times email accounts are available
+	 */
 	public Q openHours(List<OpenHours> openHours) {
 		this.openHours = openHours;
 		return self();
 	}
 
+	/**
+	 * Check account and calendar IDs for free/busy status
+	 */
 	public Q calendars(FreeBusyCalendars... calendars) {
 		this.calendars = Arrays.asList(calendars);
 		return self();
 	}
 
+	/**
+	 * Checks the validity of the availability query
+	 * @return If the query is valid
+	 */
 	public boolean isValid() {
 		return durationMinutes != null &&
 				intervalMinutes != null &&
@@ -77,6 +114,10 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 				endTime != null;
 	}
 
+	/**
+	 * Converts the availability query to a map
+	 * @return The query as a map
+	 */
 	public Map<String, Object> toMap() {
 		Map<String, Object> map = new HashMap<>();
 		Maps.putIfNotNull(map, "duration_minutes", durationMinutes);

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -149,6 +149,35 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 		return map;
 	}
 
+	void validate() {
+		if(isValid()) {
+			return;
+		}
+
+		String errorMessage = String.format(
+				"Availability query missing one or more required parameters: %s", self().missingParameters().toString());
+		throw new IllegalArgumentException(errorMessage);
+	}
+
+	StringJoiner missingParameters() {
+		StringJoiner missingParams = new StringJoiner(", ");
+
+		if(durationMinutes == null) {
+			missingParams.add("durationMinutes");
+		}
+		if(intervalMinutes == null) {
+			missingParams.add("intervalMinutes");
+		}
+		if(startTime == null) {
+			missingParams.add("startTime");
+		}
+		if(endTime == null) {
+			missingParams.add("endTime");
+		}
+
+		return missingParams;
+	}
+
 	// helper method for fluent builder style without type warnings
 	@SuppressWarnings("unchecked")
 	protected final Q self() {

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -1,10 +1,7 @@
 package com.nylas;
 
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -16,7 +16,7 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 	private Long endTime;
 	private List<FreeBusy> freeBusy;
 	private List<OpenHours> openHours;
-	protected FreeBusyCalendars calendars;
+	protected List<FreeBusyCalendars> calendars;
 
 	public Q durationMinutes(int durationMinutes) {
 		this.durationMinutes = durationMinutes;
@@ -58,8 +58,8 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 		return self();
 	}
 
-	public Q calendars(FreeBusyCalendars calendars) {
-		this.calendars = calendars;
+	public Q calendars(FreeBusyCalendars... calendars) {
+		this.calendars = Arrays.asList(calendars);
 		return self();
 	}
 

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -40,8 +40,18 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 		return self();
 	}
 
+	public Q startTime(Long startTime) {
+		this.startTime = startTime;
+		return self();
+	}
+
 	public Q endTime(Instant endTime) {
 		this.endTime = endTime.getEpochSecond();
+		return self();
+	}
+
+	public Q endTime(Long endTime) {
+		this.endTime = endTime;
 		return self();
 	}
 

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -97,6 +97,23 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 
 	/**
 	 * Check account and calendar IDs for free/busy status
+	 * <br>
+	 * Note, the mapping should be in the format of accountIds -> List of calendarIds
+	 * @deprecated Replaced by {@link #calendars(FreeBusyCalendars...)}
+	 */
+	@Deprecated
+	public Q calendars(List<Map<String, List<String>>> calendars) {
+		this.calendars = new ArrayList<>();
+		for(Map<String, List<String>> map : calendars) {
+			for(Map.Entry<String, List<String>> entry : map.entrySet()) {
+				this.calendars.add(new FreeBusyCalendars(entry.getKey(), entry.getValue()));
+			}
+		}
+		return self();
+	}
+
+	/**
+	 * Check account and calendar IDs for free/busy status
 	 */
 	public Q calendars(FreeBusyCalendars... calendars) {
 		this.calendars = Arrays.asList(calendars);

--- a/src/main/java/com/nylas/AvailabilityQuery.java
+++ b/src/main/java/com/nylas/AvailabilityQuery.java
@@ -16,8 +16,7 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 	private Long endTime;
 	private List<FreeBusy> freeBusy;
 	private List<OpenHours> openHours;
-	//TODO::Verify calendars structure
-	private List<Map<String, List<String>>> calendars;
+	protected FreeBusyCalendars calendars;
 
 	public Q durationMinutes(int durationMinutes) {
 		this.durationMinutes = durationMinutes;
@@ -59,7 +58,7 @@ abstract class AvailabilityQuery <Q extends AvailabilityQuery <Q>> {
 		return self();
 	}
 
-	public Q calendars(List<Map<String, List<String>>> calendars) {
+	public Q calendars(FreeBusyCalendars calendars) {
 		this.calendars = calendars;
 		return self();
 	}

--- a/src/main/java/com/nylas/Calendars.java
+++ b/src/main/java/com/nylas/Calendars.java
@@ -100,6 +100,11 @@ public class Calendars extends RestfulDAO<Calendar> {
 		return client.executePost(authUser, url, query.toMap(), JsonHelper.listTypeOf(FreeBusy.class));
 	}
 
+	/**
+	 * Check multiple calendars to find available time slots for a single meeting
+	 * @param query The single meeting availability query
+	 * @return The availability information; a list of time slots where all participants are available
+	 */
 	public Availability availability(SingleAvailabilityQuery query) throws IOException, RequestFailedException {
 		if(!query.isValid()) {
 			throw new IllegalArgumentException("Availability query missing one or more required parameters.");
@@ -108,6 +113,11 @@ public class Calendars extends RestfulDAO<Calendar> {
 		return client.executePost(authUser, url, query.toMap(), Availability.class);
 	}
 
+	/**
+	 * Check multiple calendars to find availability for multiple meetings with several participants
+	 * @param query The query for multiple meeting availabilities
+	 * @return The availability information; a list of all possible groupings that share time slots
+	 */
 	public List<List<ConsecutiveAvailability>> consecutiveAvailability(MultipleAvailabilityQuery query)
 			throws IOException, RequestFailedException {
 		if(!query.isValid()) {

--- a/src/main/java/com/nylas/Calendars.java
+++ b/src/main/java/com/nylas/Calendars.java
@@ -57,12 +57,26 @@ public class Calendars extends RestfulDAO<Calendar> {
 	public long count(CalendarQuery query) throws IOException, RequestFailedException {
 		return super.count(query);
 	}
-	
+
+	/**
+	 * Check calendar free or busy status for a single email
+	 * @deprecated Replaced by {@link #checkFreeBusy(FreeBusyQuery)}
+	 */
+	@Deprecated
 	public List<FreeBusy> checkFreeBusy(Instant startTime, Instant endTime, String email)
 			throws IOException, RequestFailedException {
 		return checkFreeBusy(startTime, endTime, Arrays.asList(email));
 	}
-	
+
+	/**
+	 * Check calendar free or busy status for a list of emails
+	 * @param startTime Timestamp for the beginning of the free/busy window
+	 * @param endTime Timestamp for the end of the free/busy window
+	 * @param emails Email addresses on the same domain to check
+	 * @return The free/busy timeslots
+	 * @deprecated Replaced by {@link #checkFreeBusy(FreeBusyQuery)}
+	 */
+	@Deprecated
 	public List<FreeBusy> checkFreeBusy(Instant startTime, Instant endTime, List<String> emails)
 			throws IOException, RequestFailedException {
 		HttpUrl.Builder url = getCollectionUrl().addPathSegment("free-busy");
@@ -71,6 +85,19 @@ public class Calendars extends RestfulDAO<Calendar> {
 		params.put("end_time", endTime.getEpochSecond());
 		params.put("emails", emails);
 		return client.executePost(authUser, url, params, JsonHelper.listTypeOf(FreeBusy.class));
+	}
+
+	/**
+	 * Check calendar free or busy status
+	 * @param query The free/busy query
+	 * @return The free/busy timeslots
+	 */
+	public List<FreeBusy> checkFreeBusy(FreeBusyQuery query) throws IOException, RequestFailedException {
+		if(!query.isValid()) {
+			throw new IllegalArgumentException("Free Busy query missing one or more required parameters.");
+		}
+		HttpUrl.Builder url = getCollectionUrl().addPathSegment("free-busy");
+		return client.executePost(authUser, url, query.toMap(), JsonHelper.listTypeOf(FreeBusy.class));
 	}
 
 	public Availability availability(SingleAvailabilityQuery query) throws IOException, RequestFailedException {

--- a/src/main/java/com/nylas/Calendars.java
+++ b/src/main/java/com/nylas/Calendars.java
@@ -93,9 +93,7 @@ public class Calendars extends RestfulDAO<Calendar> {
 	 * @return The free/busy timeslots
 	 */
 	public List<FreeBusy> checkFreeBusy(FreeBusyQuery query) throws IOException, RequestFailedException {
-		if(!query.isValid()) {
-			throw new IllegalArgumentException("Free Busy query missing one or more required parameters.");
-		}
+		query.validate();
 		HttpUrl.Builder url = getCollectionUrl().addPathSegment("free-busy");
 		return client.executePost(authUser, url, query.toMap(), JsonHelper.listTypeOf(FreeBusy.class));
 	}
@@ -106,9 +104,7 @@ public class Calendars extends RestfulDAO<Calendar> {
 	 * @return The availability information; a list of time slots where all participants are available
 	 */
 	public Availability availability(SingleAvailabilityQuery query) throws IOException, RequestFailedException {
-		if(!query.isValid()) {
-			throw new IllegalArgumentException("Availability query missing one or more required parameters.");
-		}
+		query.validate();
 		HttpUrl.Builder url = getCollectionUrl().addPathSegment("availability");
 		return client.executePost(authUser, url, query.toMap(), Availability.class);
 	}
@@ -120,9 +116,7 @@ public class Calendars extends RestfulDAO<Calendar> {
 	 */
 	public List<List<ConsecutiveAvailability>> consecutiveAvailability(MultipleAvailabilityQuery query)
 			throws IOException, RequestFailedException {
-		if(!query.isValid()) {
-			throw new IllegalArgumentException("Availability query missing one or more required parameters.");
-		}
+		query.validate();
 		HttpUrl.Builder url = getCollectionUrl().addPathSegment("availability").addPathSegment("consecutive");
 		return client.executePost(authUser, url, query.toMap(), JsonHelper.listTypeOf(JsonHelper.listTypeOf(ConsecutiveAvailability.class)));
 	}

--- a/src/main/java/com/nylas/FreeBusyCalendars.java
+++ b/src/main/java/com/nylas/FreeBusyCalendars.java
@@ -1,0 +1,31 @@
+package com.nylas;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FreeBusyCalendars {
+
+	private String account_id;
+	private List<String> calendar_ids = new ArrayList<>();
+
+	public String getAccountId() {
+		return account_id;
+	}
+
+	public void setAccountId(String accountId) {
+		this.account_id = accountId;
+	}
+
+	public List<String> getCalendarIds() {
+		return calendar_ids;
+	}
+
+	public void setCalendarIds(List<String> calendarIds) {
+		this.calendar_ids = calendarIds;
+	}
+
+	public void addCalendarIds(String... calendarIds) {
+		this.calendar_ids.addAll(Arrays.asList(calendarIds));
+	}
+}

--- a/src/main/java/com/nylas/FreeBusyCalendars.java
+++ b/src/main/java/com/nylas/FreeBusyCalendars.java
@@ -9,6 +9,11 @@ public class FreeBusyCalendars {
 	private String account_id;
 	private List<String> calendar_ids = new ArrayList<>();
 
+	public FreeBusyCalendars(String accountId, List<String> calendarIds) {
+		this.account_id = accountId;
+		this.calendar_ids = calendarIds;
+	}
+
 	public String getAccountId() {
 		return account_id;
 	}

--- a/src/main/java/com/nylas/FreeBusyQuery.java
+++ b/src/main/java/com/nylas/FreeBusyQuery.java
@@ -1,0 +1,44 @@
+package com.nylas;
+
+import java.util.*;
+
+public class FreeBusyQuery {
+
+	private Long startTime;
+	private Long endTime;
+	private List<String> emails;
+	private FreeBusyCalendars calendars;
+
+	public FreeBusyQuery startTime(Long startTime) {
+		this.startTime = startTime;
+		return this;
+	}
+
+	public FreeBusyQuery endTime(Long endTime) {
+		this.endTime = endTime;
+		return this;
+	}
+
+	public FreeBusyQuery emails(String... emails) {
+		this.emails = Arrays.asList(emails);
+		return this;
+	}
+
+	public FreeBusyQuery calendars(FreeBusyCalendars calendars) {
+		this.calendars = calendars;
+		return this;
+	}
+
+	public boolean isValid() {
+		return startTime != null && endTime != null && (emails != null || this.calendars != null);
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> map = new HashMap<>();
+		Maps.putIfNotNull(map, "start_time", startTime);
+		Maps.putIfNotNull(map, "end_time", endTime);
+		Maps.putIfNotNull(map, "calendars", calendars);
+		Maps.putValueOrDefault(map, "emails", emails, Collections.emptyList());
+		return map;
+	}
+}

--- a/src/main/java/com/nylas/FreeBusyQuery.java
+++ b/src/main/java/com/nylas/FreeBusyQuery.java
@@ -1,5 +1,6 @@
 package com.nylas;
 
+import java.time.Instant;
 import java.util.*;
 
 public class FreeBusyQuery {
@@ -9,8 +10,18 @@ public class FreeBusyQuery {
 	private List<String> emails;
 	private List<FreeBusyCalendars> calendars;
 
+	public FreeBusyQuery startTime(Instant startTime) {
+		this.startTime = startTime.getEpochSecond();
+		return this;
+	}
+
 	public FreeBusyQuery startTime(Long startTime) {
 		this.startTime = startTime;
+		return this;
+	}
+
+	public FreeBusyQuery endTime(Instant endTime) {
+		this.endTime = endTime.getEpochSecond();
 		return this;
 	}
 

--- a/src/main/java/com/nylas/FreeBusyQuery.java
+++ b/src/main/java/com/nylas/FreeBusyQuery.java
@@ -82,4 +82,25 @@ public class FreeBusyQuery {
 		Maps.putValueOrDefault(map, "emails", emails, Collections.emptyList());
 		return map;
 	}
+
+	void validate() {
+		if(isValid()) {
+			return;
+		}
+
+		StringJoiner missingParams = new StringJoiner(", ");
+		if(startTime == null) {
+			missingParams.add("startTime");
+		}
+		if(endTime == null) {
+			missingParams.add("endTime");
+		}
+		if(emails == null && calendars == null) {
+			missingParams.add("one of emails or calendars");
+		}
+
+		String errorMessage = String.format(
+				"Availability query missing one or more required parameters: %s", missingParams);
+		throw new IllegalArgumentException(errorMessage);
+	}
 }

--- a/src/main/java/com/nylas/FreeBusyQuery.java
+++ b/src/main/java/com/nylas/FreeBusyQuery.java
@@ -7,7 +7,7 @@ public class FreeBusyQuery {
 	private Long startTime;
 	private Long endTime;
 	private List<String> emails;
-	private FreeBusyCalendars calendars;
+	private List<FreeBusyCalendars> calendars;
 
 	public FreeBusyQuery startTime(Long startTime) {
 		this.startTime = startTime;
@@ -24,8 +24,8 @@ public class FreeBusyQuery {
 		return this;
 	}
 
-	public FreeBusyQuery calendars(FreeBusyCalendars calendars) {
-		this.calendars = calendars;
+	public FreeBusyQuery calendars(FreeBusyCalendars... calendars) {
+		this.calendars = Arrays.asList(calendars);
 		return this;
 	}
 

--- a/src/main/java/com/nylas/FreeBusyQuery.java
+++ b/src/main/java/com/nylas/FreeBusyQuery.java
@@ -3,6 +3,10 @@ package com.nylas;
 import java.time.Instant;
 import java.util.*;
 
+/**
+ * Query builder for checking for calendar free/busy
+ * @see <a href="https://developer.nylas.com/docs/api/#post/calendars/free-busy">Calendar Free or Busy</a>
+ */
 public class FreeBusyQuery {
 
 	private Long startTime;
@@ -10,40 +14,66 @@ public class FreeBusyQuery {
 	private List<String> emails;
 	private List<FreeBusyCalendars> calendars;
 
+	/**
+	 * The timestamp for the beginning of the event
+	 */
 	public FreeBusyQuery startTime(Instant startTime) {
 		this.startTime = startTime.getEpochSecond();
 		return this;
 	}
 
+	/**
+	 * The timestamp for the beginning of the event
+	 */
 	public FreeBusyQuery startTime(Long startTime) {
 		this.startTime = startTime;
 		return this;
 	}
 
+	/**
+	 * The timestamp for the end of the event
+	 */
 	public FreeBusyQuery endTime(Instant endTime) {
 		this.endTime = endTime.getEpochSecond();
 		return this;
 	}
 
+	/**
+	 * The timestamp for the end of the event
+	 */
 	public FreeBusyQuery endTime(Long endTime) {
 		this.endTime = endTime;
 		return this;
 	}
 
+	/**
+	 * Emails on the same domain to check
+	 */
 	public FreeBusyQuery emails(String... emails) {
 		this.emails = Arrays.asList(emails);
 		return this;
 	}
 
+	/**
+	 * Check account and calendar IDs for free/busy status
+	 */
 	public FreeBusyQuery calendars(FreeBusyCalendars... calendars) {
 		this.calendars = Arrays.asList(calendars);
 		return this;
 	}
 
+	/**
+	 * Checks the validity of the availability query
+	 * @return If the query is valid
+	 */
 	public boolean isValid() {
 		return startTime != null && endTime != null && (emails != null || this.calendars != null);
 	}
 
+	/**
+	 * Converts the availability query to a map
+	 * @return The query as a map
+	 */
 	public Map<String, Object> toMap() {
 		Map<String, Object> map = new HashMap<>();
 		Maps.putIfNotNull(map, "start_time", startTime);

--- a/src/main/java/com/nylas/MultipleAvailabilityQuery.java
+++ b/src/main/java/com/nylas/MultipleAvailabilityQuery.java
@@ -21,6 +21,6 @@ public class MultipleAvailabilityQuery extends AvailabilityQuery<MultipleAvailab
 
 	@Override
 	public boolean isValid() {
-		return super.isValid() && emails != null;
+		return super.isValid() && (emails != null || this.calendars != null);
 	}
 }

--- a/src/main/java/com/nylas/MultipleAvailabilityQuery.java
+++ b/src/main/java/com/nylas/MultipleAvailabilityQuery.java
@@ -3,10 +3,17 @@ package com.nylas;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Query builder for checking availability for multiple meetings
+ * @see <a href="https://developer.nylas.com/docs/api/#post/calendars/availability/consecutive">Availability for Multiple Meetings</a>
+ */
 public class MultipleAvailabilityQuery extends AvailabilityQuery<MultipleAvailabilityQuery> {
 
 	private List<List<String>> emails;
 
+	/**
+	 * Emails on the same domain to check
+	 */
 	public MultipleAvailabilityQuery emails(List<List<String>> emails) {
 		this.emails = emails;
 		return this;

--- a/src/main/java/com/nylas/MultipleAvailabilityQuery.java
+++ b/src/main/java/com/nylas/MultipleAvailabilityQuery.java
@@ -2,6 +2,7 @@ package com.nylas;
 
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
  * Query builder for checking availability for multiple meetings
@@ -29,5 +30,14 @@ public class MultipleAvailabilityQuery extends AvailabilityQuery<MultipleAvailab
 	@Override
 	public boolean isValid() {
 		return super.isValid() && (emails != null || this.calendars != null);
+	}
+
+	@Override
+	StringJoiner missingParameters() {
+		StringJoiner missingParams = super.missingParameters();
+		if(emails == null && calendars == null) {
+			missingParams.add("one of emails or calendars");
+		}
+		return missingParams;
 	}
 }

--- a/src/main/java/com/nylas/NylasClient.java
+++ b/src/main/java/com/nylas/NylasClient.java
@@ -172,7 +172,7 @@ public class NylasClient {
 
 	<T> T executeRequestWithAuth(String authUser, HttpUrl.Builder url, HttpMethod method, RequestBody body,
 			Type resultType) throws IOException, RequestFailedException {
-		return executeRequestWithAuth(authUser, url, method, body, resultType, AuthMethod.BASIC);
+		return executeRequestWithAuth(authUser, url, method, body, resultType, null);
 	}
 
 	<T> T executeRequestWithAuth(String authUser, HttpUrl.Builder url, HttpMethod method, RequestBody body,
@@ -183,6 +183,9 @@ public class NylasClient {
 
 	Request buildRequest(String authUser, HttpUrl.Builder url, HttpMethod method, RequestBody body, AuthMethod authMethod) {
 		Request.Builder builder = new Request.Builder().url(url.build());
+		if(authMethod == null) {
+			authMethod = AuthMethod.BASIC;
+		}
 		if (authUser != null) {
 			addAuthHeader(builder, authUser, authMethod);
 		}

--- a/src/main/java/com/nylas/SingleAvailabilityQuery.java
+++ b/src/main/java/com/nylas/SingleAvailabilityQuery.java
@@ -36,6 +36,11 @@ public class SingleAvailabilityQuery extends AvailabilityQuery<SingleAvailabilit
 	}
 
 	@Override
+	public boolean isValid() {
+		return super.isValid() && (emails != null || this.calendars != null);
+	}
+
+	@Override
 	public Map<String, Object> toMap() {
 		Map<String, Object> map = super.toMap();
 		Maps.putIfNotNull(map, "emails", emails);

--- a/src/main/java/com/nylas/SingleAvailabilityQuery.java
+++ b/src/main/java/com/nylas/SingleAvailabilityQuery.java
@@ -2,6 +2,7 @@ package com.nylas;
 
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
  * Query builder for checking availability for a single meeting
@@ -63,5 +64,14 @@ public class SingleAvailabilityQuery extends AvailabilityQuery<SingleAvailabilit
 		Maps.putIfNotNull(map, "emails", emails);
 		Maps.putIfNotNull(map, "round_robin", roundRobin);
 		return map;
+	}
+
+	@Override
+	StringJoiner missingParameters() {
+		StringJoiner missingParams = super.missingParameters();
+		if(emails == null && calendars == null) {
+			missingParams.add("one of emails or calendars");
+		}
+		return missingParams;
 	}
 }

--- a/src/main/java/com/nylas/SingleAvailabilityQuery.java
+++ b/src/main/java/com/nylas/SingleAvailabilityQuery.java
@@ -3,11 +3,22 @@ package com.nylas;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Query builder for checking availability for a single meeting
+ * @see <a href="https://developer.nylas.com/docs/api/#post/calendars/availability">Availability for a Single Meeting</a>
+ */
 public class SingleAvailabilityQuery extends AvailabilityQuery<SingleAvailabilityQuery> {
 
 	private List<String> emails;
 	private String roundRobin;
 
+	/**
+	 * Available round-robin options.
+	 * <br>
+	 * {@link #MAX_AVAILABILITY} will return all time slots where at least one person specified in free/busy, calendars, or emails is available.
+	 * <br>
+	 * {@code #MAX_FAIRNESS} will return time slots where the least recently booked 50% of people are available.
+	 */
 	public enum RoundRobin {
 		MAX_AVAILABILITY("max-availability"),
 		MAX_FAIRNESS("max-fairness"),
@@ -25,11 +36,17 @@ public class SingleAvailabilityQuery extends AvailabilityQuery<SingleAvailabilit
 		}
 	}
 
+	/**
+	 * Emails on the same domain to check
+	 */
 	public SingleAvailabilityQuery emails(List<String> emails) {
 		this.emails = emails;
 		return this;
 	}
 
+	/**
+	 * Finds available meeting times in a round-robin style. Unset returns collective availability.
+	 */
 	public SingleAvailabilityQuery roundRobin(RoundRobin roundRobin) {
 		this.roundRobin = roundRobin.getName();
 		return this;


### PR DESCRIPTION
# Description
In the free busy, availability, and consecutive availability endpoints of the Nylas Calendar API, there's a new field (`calendar`) that can be substituted for `emails` in the event that someone wants to check for availability/free-busy of other calendars within the same organization. 

# Usage
```java
NylasClient nylas = new NylasClient();
NylasAccount account = nylas.account("{ACCESS_TOKEN}");
Calendars calendars = account.calendars();

// To check free-busy with calendars:
FreeBusyCalendars freeBusyCalendars = new FreeBusyCalendars();
freeBusyCalendars.setAccountId("test_account_id");
freeBusyCalendars.addCalendarIds("example_calendar_id_A", "example_calendar_id_B");

FreeBusyQuery query = new FreeBusyQuery()
	.startTime(1590454800)
	.endTime(1590780800)
	.calendars(freeBusyCalendars);
List<FreeBusy> freeBusyInfo = calendars.checkFreeBusy(query);

// To check availability with calendars:
SingleAvailabilityQuery query = new SingleAvailabilityQuery()
	.durationMinutes(30)
	.startTime(Instant.now())
	.endTime(Instant.now().plus(1, ChronoUnit.HOURS))
	.intervalMinutes(10)
	.calendars(freeBusyCalendars);

Availability availability = calendars.availability(query);

// To check consecutive availability with calendars:
MultipleAvailabilityQuery consecutiveQuery = new MultipleAvailabilityQuery()
	.durationMinutes(30)
	.startTime(Instant.now())
	.endTime(Instant.now().plus(1, ChronoUnit.HOURS))
	.intervalMinutes(10)
	.calendars(freeBusyCalendars);

List<List<ConsecutiveAvailability>> consecutiveAvailability = calendars.consecutiveAvailability(consecutiveQuery);
```

# Deprecation
- Deprecated `checkFreeBusy(Instant, Instant, List<String>)` and `checkFreeBusy(Instant, Instant, String)` in favour of `checkFreeBusy(FreeBusyQuery)`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.