### PR TITLE
[CUST-601] Fix null error message when `HostedAuthentication.fetchToken()` returns an API error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+- Fix null error message when `HostedAuthentication.fetchToken()` returns an API error
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/HostedAuthentication.java
+++ b/src/main/java/com/nylas/HostedAuthentication.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 import okhttp3.HttpUrl;
+import okhttp3.Request;
 
 /**
  * Support for Nylas Hosted Auth.
@@ -46,7 +47,14 @@ public class HostedAuthentication {
 		params.put("grant_type", "authorization_code");
 		params.put("code", authorizationCode);
 
-		return application.getClient().executePost(null, tokenUrl, params, AccessToken.class);
+		// Send JSON accept header to force JSON response from this endpoint
+		Request request = new Request.Builder()
+				.url(tokenUrl.build())
+				.addHeader("Accept", "application/json")
+				.method(NylasClient.HttpMethod.POST.toString(), JsonHelper.jsonRequestBody(params))
+				.build();
+
+		return application.getClient().executeRequest(request, AccessToken.class);
 	}
 	
 	/**

--- a/src/main/java/com/nylas/HostedAuthentication.java
+++ b/src/main/java/com/nylas/HostedAuthentication.java
@@ -8,6 +8,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
+import com.nylas.NylasClient.HttpMethod;
+import com.nylas.NylasClient.HttpHeaders;
+import com.nylas.NylasClient.MediaType;
+
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 
@@ -50,8 +54,8 @@ public class HostedAuthentication {
 		// Send JSON accept header to force JSON response from this endpoint
 		Request request = new Request.Builder()
 				.url(tokenUrl.build())
-				.addHeader("Accept", "application/json")
-				.method(NylasClient.HttpMethod.POST.toString(), JsonHelper.jsonRequestBody(params))
+				.addHeader(HttpHeaders.ACCEPT.name(), MediaType.APPLICATION_JSON.getName())
+				.method(HttpMethod.POST.name(), JsonHelper.jsonRequestBody(params))
 				.build();
 
 		return application.getClient().executeRequest(request, AccessToken.class);

--- a/src/main/java/com/nylas/Messages.java
+++ b/src/main/java/com/nylas/Messages.java
@@ -6,6 +6,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.nylas.NylasClient.HttpHeaders;
+import com.nylas.NylasClient.MediaType;
+
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 
@@ -53,7 +56,7 @@ public class Messages extends RestfulDAO<Message> {
 		Request.Builder builder = new Request.Builder().url(messageUrl.build()).get();
 		client.addAuthHeader(builder, authUser);
 		Request request = builder
-				.addHeader("Accept", "message/rfc822")
+				.addHeader(HttpHeaders.ACCEPT.name(), MediaType.MESSAGE_RFC822.getName())
 				.build();
 		return client.executeRequest(request, String.class);
 	}

--- a/src/main/java/com/nylas/NylasClient.java
+++ b/src/main/java/com/nylas/NylasClient.java
@@ -31,6 +31,23 @@ public class NylasClient {
 
 	enum AuthMethod { BASIC, BEARER }
 	enum HttpMethod { GET, PUT, POST, DELETE, PATCH }
+	enum HttpHeaders { ACCEPT, AUTHORIZATION }
+	enum MediaType {
+		APPLICATION_JSON("application/json"),
+		MESSAGE_RFC822("message/rfc822"),
+
+		;
+
+		private final String name;
+
+		MediaType(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
 	
 	private static OkHttpClient.Builder defaultHttpClient() {
 		return new OkHttpClient.Builder()
@@ -196,11 +213,11 @@ public class NylasClient {
 	void addAuthHeader(Request.Builder request, String authUser, AuthMethod authMethod) {
 		switch (authMethod) {
 			case BEARER:
-				request.addHeader("Authorization", "Bearer " + authUser);
+				request.addHeader(HttpHeaders.AUTHORIZATION.name(), "Bearer " + authUser);
 				break;
 			case BASIC:
 			default:
-				request.addHeader("Authorization", Credentials.basic(authUser, ""));
+				request.addHeader(HttpHeaders.AUTHORIZATION.name(), Credentials.basic(authUser, ""));
 		}
 	}
 	


### PR DESCRIPTION
# Description
The `HostedAuthentication.fetchToken()` was returning null for the error message when encountering an API error. This is because the `/oauth/token` endpoint will return an HTML response unless the outbound call has an `Accept: application/json` header, which this PR adds.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.