### PR TITLE
Bump supported API version to v2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Changed
 
+- Bump supported API version to v2.4
+
 ### Deprecated
 
 ### Fixed

--- a/src/main/java/com/nylas/AddVersionHeadersInterceptor.java
+++ b/src/main/java/com/nylas/AddVersionHeadersInterceptor.java
@@ -8,7 +8,7 @@ import okhttp3.Response;
 
 public class AddVersionHeadersInterceptor implements Interceptor {
 
-	private static final String API_VERSION = "2.2";
+	private static final String API_VERSION = "2.4";
 	private static final String COMMIT_HASH = BuildInfo.COMMIT_ID;
 	private static final String USER_AGENT
 		= "Nylas Java SDK " + (BuildInfo.VERSION != null ? BuildInfo.VERSION : "unknown");


### PR DESCRIPTION
# Description
Bumps the supported API version to v2.4

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.