### PR TITLE
v1.12.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## [1.12.0] - Released 2022-03-08
 
 ### Added
@@ -225,6 +241,7 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.12.0...HEAD
 [1.12.0]: https://github.com/nylas/nylas-java/releases/tag/v1.12.0
 [1.11.2]: https://github.com/nylas/nylas-java/releases/tag/v1.11.2
 [1.11.1]: https://github.com/nylas/nylas-java/releases/tag/v1.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
+## [1.12.0] - Released 2022-03-08
 
 ### Added
 
@@ -23,10 +21,6 @@ This section contains changes that have been committed but not yet released.
 ### Fixed
 
 - Fix null error message when `HostedAuthentication.fetchToken()` returns an API error
-
-### Removed
-
-### Security
 
 ## [1.11.2] - Released 2022-02-01
 
@@ -231,7 +225,7 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.11.2...HEAD
+[1.12.0]: https://github.com/nylas/nylas-java/releases/tag/v1.12.0
 [1.11.2]: https://github.com/nylas/nylas-java/releases/tag/v1.11.2
 [1.11.1]: https://github.com/nylas/nylas-java/releases/tag/v1.11.1
 [1.11.0]: https://github.com/nylas/nylas-java/releases/tag/v1.11.0

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.11.2")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.12.0")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.11.2</version>
+      <version>1.12.0</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.12.0
+version=1.13.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.12.0-SNAPSHOT
+version=1.12.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New `nylas` v1.12.0 release brings the following:

### Added

- Added Outbox support (#53)
- Added support for Component CRUD (#27)
- Added support for Neural Categorizer (#54)
- Added support for `calendar` field in free-busy, availability, and consecutive availability queries (#55)
- Added field for `phone_number` in `Participant` (#56)

### Changed

- Bump supported API version to v2.4 (#58)

### Fixed

- Fix null error message when `HostedAuthentication.fetchToken()` returns an API error (#57)

### Deprecated

- Deprecated `checkFreeBusy(Instant, Instant, List<String>)` and `checkFreeBusy(Instant, Instant, String)` in favour of `checkFreeBusy(FreeBusyQuery)` (#55)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.