### PR TITLE
Fixed incorrect property name for `Event.Notification.minutes_before_event`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+- Fixed incorrect property name for `Event.Notification.minutes_before_event`
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -385,8 +385,8 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	}
 
 	public static abstract class Notification {
-		protected String type;
-		protected int minutesBeforeEvent;
+		private final String type;
+		private int minutes_before_event;
 
 		/**
 		 * For deserialization only
@@ -400,11 +400,11 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		}
 
 		public int getMinutesBeforeEvent() {
-			return minutesBeforeEvent;
+			return minutes_before_event;
 		}
 
 		public void setMinutesBeforeEvent(int minutesBeforeEvent) {
-			this.minutesBeforeEvent = minutesBeforeEvent;
+			this.minutes_before_event = minutesBeforeEvent;
 		}
 	}
 
@@ -437,8 +437,8 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 		@Override
 		public String toString() {
-			return "EmailNotification [type=" + type + ", body=" + body + ", subject=" + subject +
-					", minutesBeforeEvent=" + minutesBeforeEvent + "]";
+			return "EmailNotification [type=" + getType() + ", body=" + body + ", subject=" + subject +
+					", minutesBeforeEvent=" + getMinutesBeforeEvent() + "]";
 		}
 	}
 
@@ -462,8 +462,8 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 		@Override
 		public String toString() {
-			return "SMSNotification [type=" + type + ", message=" + message
-					+ ", minutesBeforeEvent=" + minutesBeforeEvent + "]";
+			return "SMSNotification [type=" + getType() + ", message=" + message
+					+ ", minutesBeforeEvent=" + getMinutesBeforeEvent() + "]";
 		}
 	}
 
@@ -496,8 +496,8 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 		@Override
 		public String toString() {
-			return "WebhookNotification [type=" + type +", url=" + url + ", payload=" + payload
-					+ ", minutesBeforeEvent=" + minutesBeforeEvent + "]";
+			return "WebhookNotification [type=" + getType() +", url=" + url + ", payload=" + payload
+					+ ", minutesBeforeEvent=" + getMinutesBeforeEvent() + "]";
 		}
 	}
 


### PR DESCRIPTION
# Description
`Event.Notification` had a parameter (minutesBeforeEvent) that was supposed to be in snake_case instead of camelCase for serialization/deserialization purposes. This caused any event with notifications being saved to throw an error.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.