### PR TITLE
[TSDK-264] Add support for `authentication_type` in Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This section contains changes that have been committed but not yet released.
 ### Added
 
 - Added UAS Support (Integrations API, Grants API, UAS Hosted Authentication)
+- Add `authentication_type` field to `Account`
 
 ### Changed
 

--- a/src/main/java/com/nylas/Account.java
+++ b/src/main/java/com/nylas/Account.java
@@ -11,6 +11,7 @@ public class Account extends AccountOwnedModel {
 	private String email;
 	private String provider;
 	private String sync_state;
+	private String authentication_type;
 	private Boolean trial;
 	private Map<String, String> metadata;
 	
@@ -29,6 +30,10 @@ public class Account extends AccountOwnedModel {
 	public String getSyncState() {
 		return sync_state;
 	}
+
+	public String getAuthenticationType() {
+		return authentication_type;
+	}
 	
 	public Boolean getTrial() {
 		return trial;
@@ -40,8 +45,15 @@ public class Account extends AccountOwnedModel {
 
 	@Override
 	public String toString() {
-		return "Account [id=" + getId() + ", billing_state=" + billing_state + ", email=" + email + ", provider=" + provider
-				+ ", sync_state=" + sync_state + ", trial=" + trial + ", metadata=" + metadata + "]";
+		return "Account [" +
+				"id='" + getId() + '\'' +
+				", billing_state='" + billing_state + '\'' +
+				", email='" + email + '\'' +
+				", provider='" + provider + '\'' +
+				", sync_state='" + sync_state + '\'' +
+				", authentication_type='" + authentication_type + '\'' +
+				", trial=" + trial +
+				", metadata=" + metadata +
+				']';
 	}
-	
 }


### PR DESCRIPTION
# Description
This PR adds support for new `authentication_method` field in `Account`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.