### PR TITLE
[TSDK-274] Support revoking single access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add support for revoking a single access token
+
 ### Changed
 
 ### Deprecated

--- a/src/examples/java/com/nylas/examples/other/AccountsExample.java
+++ b/src/examples/java/com/nylas/examples/other/AccountsExample.java
@@ -55,6 +55,7 @@ public class AccountsExample {
 		
 		//accounts.delete(first.getId());
 		//accounts.revokeAllTokensForAccount(first.getId(), "blahblah");
+		//accounts.revoke(conf.get("access.token"));
 	}
 
 }

--- a/src/main/java/com/nylas/Accounts.java
+++ b/src/main/java/com/nylas/Accounts.java
@@ -43,6 +43,15 @@ public class Accounts extends RestfulDAO<Account> {
 		HttpUrl.Builder url = getInstanceUrl(accountId).addPathSegment("upgrade");
 		client.executePost(authUser, url, null, null);
 	}
+
+	/**
+	 * Revoke a single access Token
+	 * @param accessToken The access token to revoke
+	 */
+	public void revoke(String accessToken) throws RequestFailedException, IOException {
+		HttpUrl.Builder url = client.newUrlBuilder().addPathSegments("oauth/revoke");
+		client.executePost(accessToken, url, null, null);
+	}
 	
 	public void revokeAllTokensForAccount(String accountId, String keepAccessToken)
 			throws IOException, RequestFailedException {


### PR DESCRIPTION
# Description
This PR adds support for revoking a single access token.

# Usage
```java
NylasClient nylas = new NylasClient();
NylasApplication application = client.application("CLIENT_ID", "CLIENT_SECRET");
Accounts accounts = application.accounts();

accounts.revoke("ACCESS_TOKEN_TO_REVOKE");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.