### PR TITLE
Fixed Participant status not being sent to the API when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+* Fixed `Participant` status not being sent to the API when set
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -203,7 +203,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		List<Map<String, Object>> participantWritableFields = null;
 		if(participants != null && !participants.isEmpty()) {
 			participantWritableFields = participants.stream()
-					.map(Participant::getWritableFields)
+					.map(participant -> participant.getWritableFields(creation))
 					.collect(Collectors.toList());
 		}
 

--- a/src/main/java/com/nylas/Participant.java
+++ b/src/main/java/com/nylas/Participant.java
@@ -5,10 +5,15 @@ import java.util.Map;
 
 public class Participant {
 
+	/** The participant's full name */
 	private String name;
+	/** The participant's email address */
 	private String email;
+	/** The participant's phone number */
 	private String phone_number;
+	/** The participant's attendance status. See {@link Participant.Status} for allowed values. */
 	private String status;
+	/** A comment for the participant */
 	private String comment;
 
 	/** Supported values for participant status */
@@ -55,32 +60,45 @@ public class Participant {
 		return comment;
 	}
 
+	/** Set the participant's full name */
 	public Participant name(String name) {
 		this.name = name;
 		return this;
 	}
 
+	/** Set the participant's phone number */
 	public Participant phoneNumber(String phoneNumber) {
 		this.phone_number = phoneNumber;
 		return this;
 	}
 
+	/** Set the participant's attendance status */
 	public Participant status(Status status) {
 		this.status = status.toString();
 		return this;
 	}
 
+	/**
+	 * Set the participant's attendance status
+	 * @deprecated Use {@link #status(Status)} instead
+	 */
 	@Deprecated
 	public Participant status(String status) {
 		this.status = status;
 		return this;
 	}
 
+	/** Set a comment for the participant */
 	public Participant comment(String comment) {
 		this.comment = comment;
 		return this;
 	}
 
+	/**
+	 * Serializes the object to a map with only the writable fields
+	 * @param creation If the object is being created
+	 * @return The object as a map
+	 */
 	Map<String, Object> getWritableFields(boolean creation) {
 		Map<String, Object> params = new HashMap<>();
 		if (creation) {

--- a/src/main/java/com/nylas/Participant.java
+++ b/src/main/java/com/nylas/Participant.java
@@ -65,6 +65,11 @@ public class Participant {
 		return this;
 	}
 
+	public Participant status(Status status) {
+		this.status = status.toString();
+		return this;
+	}
+
 	@Deprecated
 	public Participant status(String status) {
 		this.status = status;
@@ -76,8 +81,11 @@ public class Participant {
 		return this;
 	}
 
-	Map<String, Object> getWritableFields() {
+	Map<String, Object> getWritableFields(boolean creation) {
 		Map<String, Object> params = new HashMap<>();
+		if (creation) {
+			Maps.putIfNotNull(params, "status", status);
+		}
 		Maps.putIfNotNull(params, "name", name);
 		Maps.putIfNotNull(params, "email", email);
 		Maps.putIfNotNull(params, "phone_number", phone_number);

--- a/src/main/java/com/nylas/Participant.java
+++ b/src/main/java/com/nylas/Participant.java
@@ -10,6 +10,21 @@ public class Participant {
 	private String phone_number;
 	private String status;
 	private String comment;
+
+	/** Supported values for participant status */
+	public enum Status {
+		YES,
+		NO,
+		MAYBE,
+		NOREPLY,
+
+		;
+
+		@Override
+		public String toString() {
+			return super.toString().toLowerCase();
+		}
+	}
 	
 	/** For deserialiation only */ public Participant() {}
 	


### PR DESCRIPTION
# Description
The API allows for event participants to have a status set for them on create. In the Java SDK, the setter was deprecated and was not transmitting the value on create. Now we introduced a new Enum with all the possible participant status values (`Participant.Status`) and a new setter. On creating a new event, the Java SDK will now send the participant status to the API, if set.

```java
Participant participant = new Participant("test@nylas.com")
    .name("Test Participant")
    .status(Participant.Status.YES);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.