### PR TITLE
Add missing order and emails field in calendar availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add missing `order` and `emails` fields in `Availability` and `TimeSlot`
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/Availability.java
+++ b/src/main/java/com/nylas/Availability.java
@@ -4,13 +4,17 @@ import java.util.List;
 
 public class Availability {
 	private List<TimeSlot> time_slots;
+	private List<String> order;
 
 	public List<TimeSlot> getTimeSlots() {
 		return time_slots;
 	}
+	public List<String> getOrder() {
+		return order;
+	}
 
 	@Override
 	public String toString() {
-		return "Availability [time_slots=" + time_slots + "]";
+		return "Availability [time_slots=" + time_slots + ", order=" + order + "]";
 	}
 }

--- a/src/main/java/com/nylas/TimeSlot.java
+++ b/src/main/java/com/nylas/TimeSlot.java
@@ -1,6 +1,7 @@
 package com.nylas;
 
 import java.time.Instant;
+import java.util.List;
 
 public class TimeSlot {
 	private String status;
@@ -9,6 +10,7 @@ public class TimeSlot {
 	// The availability endpoint uses these terms instead
 	private Long start;
 	private Long end;
+	private List<String> emails;
 
 	public String getStatus() {
 		return status;
@@ -30,6 +32,10 @@ public class TimeSlot {
 		}
 	}
 
+	public List<String> getEmails() {
+		return emails;
+	}
+
 	// The Setters use the availability notation because that's the only
 	// case someone would be modifying/setting start and end times
 	public void setStartTime(Instant startTime) {
@@ -46,6 +52,7 @@ public class TimeSlot {
 
 	@Override
 	public String toString() {
-		return "TimeSlot [status=" + status + ", start_time=" + getStartTime() + ", end_time=" + getEndTime() + "]";
+		return "TimeSlot [status=" + status + ", start_time=" + getStartTime() + ", end_time=" + getEndTime()
+				+ ", emails=" + emails + "]";
 	}
 }


### PR DESCRIPTION
# Description
For calendar availability the response now includes `order` and for time slot there is an `emails` field as well. This PR adds both fields.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.