### PR TITLE
v1.13.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,14 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
+## [1.13.1] - Released 2022-04-22
 
 ### Added
 
 * Add missing `order` and `emails` fields in `Availability` and `TimeSlot`
 
-### Changed
-
-### Deprecated
-
 ### Fixed
 
 * Fixed `Participant` status not being sent to the API when set
-
-### Removed
-
-### Security
 
 ## [1.13.0] - Released 2022-03-31
 
@@ -261,7 +251,7 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.13.0...HEAD
+[1.13.1]: https://github.com/nylas/nylas-java/releases/tag/v1.13.1
 [1.13.0]: https://github.com/nylas/nylas-java/releases/tag/v1.13.0
 [1.12.0]: https://github.com/nylas/nylas-java/releases/tag/v1.12.0
 [1.11.2]: https://github.com/nylas/nylas-java/releases/tag/v1.11.2

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.13.0")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.13.1")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.13.0</version>
+      <version>1.13.1</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.14.0-SNAPSHOT
+version=1.13.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description

New `nylas` v1.13.0 release brings the following:

### Added

* Add missing `order` and `emails` fields in `Availability` and `TimeSlot` (#69)

### Fixed

* Fixed `Participant` status not being sent to the API when set (#68)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.