### PR TITLE
Fixed enum value for `Scheduler.Config.Booking.OpeningHours.Days.Sunday`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+* Fixed enum value for `Scheduler.Config.Booking.OpeningHours.Days.Sunday`
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/scheduler/Scheduler.java
+++ b/src/main/java/com/nylas/scheduler/Scheduler.java
@@ -662,7 +662,7 @@ public class Scheduler extends AccountOwnedModel implements JsonObject {
 					THURSDAY('R'),
 					FRIDAY('F'),
 					SATURDAY('S'),
-					SUNDAY('N'),
+					SUNDAY('U'),
 
 					;
 


### PR DESCRIPTION
# Description
As per API documentation, the value for `Sunday` should be `U` not `N`.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.