### PR TITLE
Add support for calendar free-busy scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This section contains changes that have been committed but not yet released.
 
 * Add missing fields in Scheduler
 * Add support for collective and group events
+* Add support for calendar free-busy scope
 
 ### Changed
 

--- a/src/main/java/com/nylas/Scope.java
+++ b/src/main/java/com/nylas/Scope.java
@@ -53,6 +53,11 @@ public enum Scope {
 	 * Read calendars and events.
 	 */
 	CALENDAR_READ_ONLY("calendar.read_only"),
+
+	/**
+	 * EWS accounts should add this scope to access the free/busy endpoint.
+	 */
+	CALENDAR_FREE_BUSY("calendar.free_busy"),
 	
 	/**
 	 * Read available room resources for an account.


### PR DESCRIPTION
# Description
This PR adds support for the `calendar.free_busy` scope, used by EWS accounts to allow access to the free busy endpoint

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.