### PR TITLE
 v1.14.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## [1.14.0] - Released 2022-06-14
 
 ### Added
@@ -264,6 +280,7 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.14.0...HEAD
 [1.14.0]: https://github.com/nylas/nylas-java/releases/tag/v1.14.0
 [1.13.1]: https://github.com/nylas/nylas-java/releases/tag/v1.13.1
 [1.13.0]: https://github.com/nylas/nylas-java/releases/tag/v1.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,17 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
+## [1.14.0] - Released 2022-06-14
 
 ### Added
 
 * Add missing fields in Scheduler
 * Add support for collective and group events
 * Add support for calendar free-busy scope
-
-### Changed
-
-### Deprecated
+* Add `redirect_on_error` parameter for Hosted Authentication
 
 ### Fixed
 
 * Fixed enum value for `Scheduler.Config.Booking.OpeningHours.Days.Sunday`
-
-### Removed
-
-### Security
 
 ## [1.13.1] - Released 2022-04-22
 
@@ -273,7 +264,7 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.13.1...HEAD
+[1.14.0]: https://github.com/nylas/nylas-java/releases/tag/v1.14.0
 [1.13.1]: https://github.com/nylas/nylas-java/releases/tag/v1.13.1
 [1.13.0]: https://github.com/nylas/nylas-java/releases/tag/v1.13.0
 [1.12.0]: https://github.com/nylas/nylas-java/releases/tag/v1.12.0

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.13.1")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.14.0")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.13.1</version>
+      <version>1.14.0</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.14.0-SNAPSHOT
+version=1.14.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.14.0
+version=1.15.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New `nylas` v1.14.0 release brings the following:

### Added

* Add missing fields in Scheduler (#71)
* Add support for collective and group events (#73)
* Add support for calendar free-busy scope (#75)
* Add `redirect_on_error` parameter for Hosted Authentication (#72)

### Fixed

* Fixed enum value for `Scheduler.Config.Booking.OpeningHours.Days.Sunday` (#74)

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.