### PR TITLE
Add `interval_minutes` field in Scheduler booking config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
-* Add new `interval_minutes` field in Scheduler booking config
+* Add `interval_minutes` field in Scheduler booking config
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add new `interval_minutes` field in Scheduler booking config
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/scheduler/Scheduler.java
+++ b/src/main/java/com/nylas/scheduler/Scheduler.java
@@ -405,6 +405,7 @@ public class Scheduler extends AccountOwnedModel implements JsonObject {
 			private Integer min_booking_notice;
 			private Integer min_buffer;
 			private Integer min_cancellation_notice;
+			private Integer interval_minutes;
 			private Boolean calendar_invite_to_guests;
 			private Boolean confirmation_emails_to_guests;
 			private Boolean confirmation_emails_to_host;
@@ -439,6 +440,10 @@ public class Scheduler extends AccountOwnedModel implements JsonObject {
 
 			public Integer getMinCancellationNotice() {
 				return min_cancellation_notice;
+			}
+
+			public Integer getIntervalMinutes() {
+				return interval_minutes;
 			}
 
 			public Boolean getCalendarInviteToGuests() {
@@ -497,6 +502,13 @@ public class Scheduler extends AccountOwnedModel implements JsonObject {
 				this.min_cancellation_notice = minCancellationNotice;
 			}
 
+			public void setIntervalMinutes(Integer intervalMinutes) {
+				if(intervalMinutes != null && (intervalMinutes <= 0 || intervalMinutes % 5 != 0)) {
+					throw new IllegalArgumentException("intervalMinutes must be a non-zero positive integer, divisible by 5.");
+				}
+				this.interval_minutes = intervalMinutes;
+			}
+
 			public void setCalendarInviteToGuests(Boolean calendarInviteToGuests) {
 				this.calendar_invite_to_guests = calendarInviteToGuests;
 			}
@@ -543,6 +555,7 @@ public class Scheduler extends AccountOwnedModel implements JsonObject {
 						", minBookingNotice=" + min_booking_notice +
 						", minBuffer=" + min_buffer +
 						", minCancellationNotice=" + min_cancellation_notice +
+						", intervalMinutes=" + interval_minutes +
 						", calendarInviteToGuests=" + calendar_invite_to_guests +
 						", confirmationEmailsToGuests=" + confirmation_emails_to_guests +
 						", confirmationEmailsToHost=" + confirmation_emails_to_host +


### PR DESCRIPTION
# Description
This PR adds the `interval_minutes` in `Scheduler.Booking.Config`. Note that this field only takes a non-zero, positive integer that's divisible by 5. Else we have validation in the setter that would throw the appropriate IllegalArgumentException.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.