### PR TITLE
Add `metadata` field to `JobStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add `metadata` field to `JobStatus`
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/JobStatus.java
+++ b/src/main/java/com/nylas/JobStatus.java
@@ -1,11 +1,14 @@
 package com.nylas;
 
+import java.util.Map;
+
 public class JobStatus extends AccountOwnedModel {
 
 	private String action;
 	private Long created_at;
 	private String object;
 	private String status;
+	Map<String, Object> metadata;
 	
 	public String getAction() {
 		return action;
@@ -22,7 +25,11 @@ public class JobStatus extends AccountOwnedModel {
 	public String getStatus() {
 		return status;
 	}
-	
+
+	public Map<String, Object> getMetadata() {
+		return metadata;
+	}
+
 	/**
 	 * Returns the id of this job status object.
 	 * <p>
@@ -54,8 +61,16 @@ public class JobStatus extends AccountOwnedModel {
 
 	@Override
 	public String toString() {
-		return "JobStatus [action=" + action + ", createdAt=" + created_at + ", jobObjectId=" + getJobObjectId()
-				+ ", object=" + object + ", status=" + status+ ", accountId=" + getAccountId() + ", id=" + getId() + "]";
+		return "JobStatus [" +
+				"action='" + action + '\'' +
+				", created_at=" + created_at +
+				", object='" + object + '\'' +
+				", status='" + status + '\'' +
+				", metadata=" + metadata +
+				", jobObjectId=" + getJobObjectId() +
+				", accountId=" + getAccountId() +
+				", id=" + getId() +
+				']';
 	}
 	
 	static class JobStatusJson {

--- a/src/main/java/com/nylas/JobStatus.java
+++ b/src/main/java/com/nylas/JobStatus.java
@@ -8,7 +8,7 @@ public class JobStatus extends AccountOwnedModel {
 	private Long created_at;
 	private String object;
 	private String status;
-	Map<String, Object> metadata;
+	private Map<String, Object> metadata;
 	
 	public String getAction() {
 		return action;


### PR DESCRIPTION
# Description
This PR adds a new `metadata` field to the `JobStatus` class.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.