### PR TITLE
Event improvments: add support for Event Reminders, new fields and add missing query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add missing event query parameters
+* Add support for Event reminders
+* Add support for additional Event fields
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -18,12 +18,16 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	private String calendar_id;
 	private String ical_uid;
 	private String master_event_id;
+	private String customer_event_id;
 	private String event_collection_id;
 	private String title;
 	private String description;
 	private String location;
 	private String owner;
 	private String status;
+	private String organizer_email;
+	private String organizer_name;
+	private String visibility;
 	private Integer capacity;
 	private Boolean read_only;
 	private Boolean busy;
@@ -79,6 +83,22 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 	public String getOwner() {
 		return owner;
+	}
+
+	public String getCustomerEventId() {
+		return customer_event_id;
+	}
+
+	public String getOrganizerEmail() {
+		return organizer_email;
+	}
+
+	public String getOrganizerName() {
+		return organizer_name;
+	}
+
+	public String getVisibility() {
+		return visibility;
 	}
 
 	public List<Participant> getParticipants() {
@@ -182,6 +202,10 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 	public void setLocation(String location) {
 		this.location = location;
+	}
+
+	public void setCustomerEventId(String customerEventId) {
+		this.customer_event_id = customerEventId;
 	}
 
 	public void setCapacity(Integer capacity) {

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -31,6 +31,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	private When when;
 	private Conferencing conferencing;
 	private Recurrence recurrence;
+	private Reminders reminders;
 	private List<String> round_robin_order = new ArrayList<>();
 	private List<Notification> notifications = new ArrayList<>();
 	private List<Participant> participants = new ArrayList<>();
@@ -118,6 +119,10 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 	public Recurrence getRecurrence() {
 		return recurrence;
+	}
+
+	public Reminders getReminders() {
+		return reminders;
 	}
 
 	public String getMasterEventId() {
@@ -211,6 +216,10 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		this.recurrence = recurrence;
 	}
 
+	public void setReminders(Reminders reminders) {
+		this.reminders = reminders;
+	}
+
 	/**
 	 * Add single metadata key-value pair to the event
 	 * @param key The key of the metadata entry
@@ -260,6 +269,11 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		Map<String, Object> params = new HashMap<>();
 		if (creation) {
 			Maps.putIfNotNull(params, "calendar_id", getCalendarId());
+			// Reminders, when creating an event, need to be included in the main object
+			if(reminders != null && reminders.reminderMinutes != null && reminders.reminderMethod != null) {
+				params.put("reminder_minutes", String.format("[%d]", reminders.reminderMinutes));
+				params.put("reminder_method", reminders.reminderMethod);
+			}
 		}
 
 		List<Map<String, Object>> participantWritableFields = null;
@@ -443,6 +457,48 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			public String toString() {
 				return String.format("Autocreate [settings=%s]", settings);
 			}
+		}
+	}
+
+	public static class Reminders {
+		private Integer reminderMinutes;
+		private String reminderMethod;
+
+		/**
+		 * Enumeration containing the reminder methods
+		 */
+		public enum ReminderMethod {
+			EMAIL,
+			POPUP,
+			DISPLAY,
+			SOUND,
+
+			;
+
+			@Override
+			public String toString() {
+				return super.toString().toLowerCase();
+			}
+		}
+
+		/** For deserialization only */ public Reminders() {}
+
+		public Reminders(int reminderMinutes, ReminderMethod reminderMethod) {
+			this.reminderMinutes = reminderMinutes;
+			this.reminderMethod = reminderMethod.toString();
+		}
+
+		public Integer getReminderMinutes() {
+			return reminderMinutes;
+		}
+
+		public ReminderMethod reminderMethod() {
+			return ReminderMethod.valueOf(reminderMethod.toUpperCase());
+		}
+
+		@Override
+		public String toString() {
+			return "Reminders [reminderMinutes=" + getReminderMinutes() + ", reminderMethod=" + reminderMethod() + "]";
 		}
 	}
 

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -294,9 +294,9 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		if (creation) {
 			Maps.putIfNotNull(params, "calendar_id", getCalendarId());
 			// Reminders, when creating an event, need to be included in the main object
-			if(reminders != null && reminders.reminderMinutes != null && reminders.reminderMethod != null) {
-				params.put("reminder_minutes", String.format("[%d]", reminders.reminderMinutes));
-				params.put("reminder_method", reminders.reminderMethod);
+			if(reminders != null && reminders.reminder_minutes != null && reminders.reminder_method != null) {
+				params.put("reminder_minutes", String.format("[%d]", reminders.reminder_minutes));
+				params.put("reminder_method", reminders.reminder_method);
 			}
 		}
 
@@ -485,8 +485,8 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	}
 
 	public static class Reminders {
-		private Integer reminderMinutes;
-		private String reminderMethod;
+		private final Integer reminder_minutes;
+		private final String reminder_method;
 
 		/**
 		 * Enumeration containing the reminder methods
@@ -505,24 +505,26 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			}
 		}
 
-		/** For deserialization only */ public Reminders() {}
-
 		public Reminders(int reminderMinutes, ReminderMethod reminderMethod) {
-			this.reminderMinutes = reminderMinutes;
-			this.reminderMethod = reminderMethod.toString();
+			this.reminder_minutes = reminderMinutes;
+			this.reminder_method = reminderMethod.toString();
 		}
 
 		public Integer getReminderMinutes() {
-			return reminderMinutes;
+			return reminder_minutes;
 		}
 
-		public ReminderMethod reminderMethod() {
-			return ReminderMethod.valueOf(reminderMethod.toUpperCase());
+		public ReminderMethod getReminderMethod() {
+			try {
+				return ReminderMethod.valueOf(reminder_method.toUpperCase());
+			} catch (IllegalArgumentException | NullPointerException e) {
+				return null;
+			}
 		}
 
 		@Override
 		public String toString() {
-			return "Reminders [reminderMinutes=" + getReminderMinutes() + ", reminderMethod=" + reminderMethod() + "]";
+			return "Reminders [reminderMinutes=" + getReminderMinutes() + ", reminderMethod=" + getReminderMethod() + "]";
 		}
 	}
 

--- a/src/main/java/com/nylas/EventQuery.java
+++ b/src/main/java/com/nylas/EventQuery.java
@@ -11,11 +11,13 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 
 	private Boolean expandRecurring;
 	private Boolean showCancelled;
+	private Boolean busy;
 	private String eventId;
 	private String calendarId;
 	private String title;
 	private String description;
 	private String location;
+	private String participants;
 	private Instant startsBefore;
 	private Instant startsAfter;
 	private Instant endsBefore;
@@ -35,6 +37,9 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 		if (showCancelled != null) {
 			url.addQueryParameter("show_cancelled", showCancelled.toString());
 		}
+		if (busy != null) {
+			url.addQueryParameter("busy", busy.toString());
+		}
 		if (eventId != null) {
 			url.addQueryParameter("event_id", eventId);
 		}
@@ -49,6 +54,9 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 		}
 		if (location != null) {
 			url.addQueryParameter("location", location);
+		}
+		if (participants != null) {
+			url.addQueryParameter("participants", participants);
 		}
 		if (startsBefore != null) {
 			url.addQueryParameter("starts_before", Instants.formatEpochSecond(startsBefore));
@@ -92,6 +100,11 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 		return this;
 	}
 	
+	public EventQuery busy(Boolean busy) {
+		this.busy = busy;
+		return this;
+	}
+
 	public EventQuery eventId(String eventId) {
 		this.eventId = eventId;
 		return this;
@@ -114,6 +127,11 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 	
 	public EventQuery location(String location) {
 		this.location = location;
+		return this;
+	}
+
+	public EventQuery participants(String participants) {
+		this.participants = participants;
 		return this;
 	}
 

--- a/src/main/java/com/nylas/EventQuery.java
+++ b/src/main/java/com/nylas/EventQuery.java
@@ -89,67 +89,110 @@ public class EventQuery extends RestfulQuery<EventQuery> {
 			metadataQuery.addParameters(url);
 		}
 	}
-	
+
+	/**
+	 * Return events matching the specified recurrence. If the recurrence is true, the results will expand single
+	 * recurring events into individual event instances that fall within the requested time range.
+	 */
 	public EventQuery expandRecurring(Boolean expandRecurring) {
 		this.expandRecurring = expandRecurring;
 		return this;
 	}
-	
+
+	/**
+	 * Return events that have a status of cancelled.
+	 * If an event is recurring, then it returns no matter the value of showCancelled.
+	 */
 	public EventQuery showCancelled(Boolean showCancelled) {
 		this.showCancelled = showCancelled;
 		return this;
 	}
-	
+
+	/**
+	 * Returns events with a matching busy status.
+	 */
 	public EventQuery busy(Boolean busy) {
 		this.busy = busy;
 		return this;
 	}
 
+	/**
+	 * Return the event matching the specified event ID.
+	 */
 	public EventQuery eventId(String eventId) {
 		this.eventId = eventId;
 		return this;
 	}
-	
+
+	/**
+	 * Return events belonging to the specified calendar ID.
+	 */
 	public EventQuery calendarId(String calendarId) {
 		this.calendarId = calendarId;
 		return this;
 	}
-	
+
+	/**
+	 * Return events matching the specified title.
+	 */
 	public EventQuery title(String title) {
 		this.title = title;
 		return this;
 	}
-	
+
+	/**
+	 * Return events matching the specified description.
+	 */
 	public EventQuery description(String description) {
 		this.description = description;
 		return this;
 	}
-	
+
+	/**'
+	 * Return events matching the specified location.
+	 */
 	public EventQuery location(String location) {
 		this.location = location;
 		return this;
 	}
 
+	/**'
+	 * Return events containing participant details.
+	 * Can search with participant name, email address, status, phone number, etc.
+	 * This will not search with multiple arguments.
+	 */
 	public EventQuery participants(String participants) {
 		this.participants = participants;
 		return this;
 	}
 
+	/**
+	 * Return events starting before the specified timestamp.
+	 */
 	public EventQuery startsBefore(Instant startsBefore) {
 		this.startsBefore = startsBefore;
 		return this;
 	}
-	
+
+	/**
+	 * Return events starting after the specified timestamp.
+	 */
 	public EventQuery startsAfter(Instant startsAfter) {
 		this.startsAfter = startsAfter;
 		return this;
 	}
-	
+
+	/**
+	 * Return events ending before the specified timestamp.
+	 */
 	public EventQuery endsBefore(Instant endsBefore) {
 		this.endsBefore = endsBefore;
 		return this;
 	}
-	
+
+	/**
+	 * Return events ending after the specified timestamp.
+	 */
 	public EventQuery endsAfter(Instant endsAfter) {
 		this.endsAfter = endsAfter;
 		return this;


### PR DESCRIPTION
# Description
This PR is focused around improvements for Event-related implementations. Specifically, this PR:
* Add support for Event reminders
* Add support for additional Event fields
* Add missing Event query parameters

# Usage
To use Event reminders:
```java
ZoneId startTz = ZoneId.of("America/Los_Angeles");
ZoneId endTz = ZoneId.of("America/New_York");
ZonedDateTime startTime = ZonedDateTime.now(startTz);
ZonedDateTime endTime = startTime.plusHours(2).withZoneSameInstant(endTz);

Event event = new Event("calendar_id", new Timespan(startTime, endTime));
event.setTitle("Surprise Party");

// Add event reminders
event.setReminders(new Event.Reminders(20, Event.Reminders.ReminderMethod.EMAIL));

// Create the event
Event created = events.create(event, true);
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.