### PR TITLE
Add expanded in query parameter

### DIFF
--- a/src/main/java/com/nylas/RestfulDAO.java
+++ b/src/main/java/com/nylas/RestfulDAO.java
@@ -62,6 +62,7 @@ public abstract class RestfulDAO<M extends RestfulModel> {
 	
 	protected M get(String id) throws IOException, RequestFailedException {
 		HttpUrl.Builder messageUrl = getInstanceUrl(id);
+		setView(messageUrl,"expanded");
 		return client.executeGet(authUser, messageUrl, modelClass, authMethod);
 	}
 	


### PR DESCRIPTION
# Description
Add query parameter view=expanded in `get` method in order to get headers when getting a single message
# Usage
```
NylasClient nylasClient=new NylasClient();
		Message message=nylasClient.account("access_token").messages().get("access_token");
		System.out.println(message.getHeaders());
```