### PR TITLE
Fix unable to remove event participants once set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+* Fixed issue where `Event` participants could never be entirely removed once set
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -300,7 +300,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			}
 		}
 
-		List<Map<String, Object>> participantWritableFields = null;
+		List<Map<String, Object>> participantWritableFields = Collections.emptyList();
 		if(participants != null && !participants.isEmpty()) {
 			participantWritableFields = participants.stream()
 					.map(participant -> participant.getWritableFields(creation))

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -254,6 +254,13 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	}
 
 	/**
+	 * Remove all metadata from the event
+	 */
+	public void clearMetadata() {
+		this.metadata.clear();
+	}
+
+	/**
 	 * Add one (or many) notifications to the event
 	 * @param notifications The notification(s) to append to the event's notification list
 	 */
@@ -265,11 +272,25 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	}
 
 	/**
+	 * Remove all notifications from the event
+	 */
+	public void clearNotifications() {
+		this.notifications.clear();
+	}
+
+	/**
 	 * Add one (or many) participants to the event
 	 * @param participants The participant(s) to append to the event's participant list
 	 */
 	public void addParticipants(Participant... participants) {
 		this.participants.addAll(Arrays.asList(participants));
+	}
+
+	/**
+	 * Remove all participants from the event
+	 */
+	public void clearParticipants() {
+		this.participants.clear();
 	}
 
 	/**


### PR DESCRIPTION
# Description
The participants list was defaulted to null, which meant when attempting to serialize the object, the value is discarded. Now the default is an empty list, so if the user empties the list of participants, the object will serialize that field to an empty list.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.