### PR TITLE
Add support for getting a single expanded message/thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add support for getting a single expanded message and thread
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/Messages.java
+++ b/src/main/java/com/nylas/Messages.java
@@ -26,8 +26,26 @@ public class Messages extends RestfulDAO<Message> {
 		return super.list(query);
 	}
 
+	/**
+	 * Get a single message by ID
+	 * @param id The message ID
+	 * @return The requested message
+	 */
 	@Override
 	public Message get(String id) throws IOException, RequestFailedException {
+		return get(id, false);
+	}
+
+	/**
+	 * Get a single message by ID
+	 * @param id The message ID
+	 * @param expanded If true, the message will return with additional RFC2822 headers
+	 * @return The requested message
+	 */
+	public Message get(String id, boolean expanded) throws IOException, RequestFailedException {
+		if(expanded) {
+			setView(getCollectionUrl(), "expanded");
+		}
 		return super.get(id);
 	}
 

--- a/src/main/java/com/nylas/RestfulDAO.java
+++ b/src/main/java/com/nylas/RestfulDAO.java
@@ -175,7 +175,7 @@ public abstract class RestfulDAO<M extends RestfulModel> {
 		}
 	}
 	
-	private static void setView(HttpUrl.Builder url, String view) {
+	protected static void setView(HttpUrl.Builder url, String view) {
 		url.addQueryParameter("view", view);
 	}
 

--- a/src/main/java/com/nylas/Threads.java
+++ b/src/main/java/com/nylas/Threads.java
@@ -21,8 +21,26 @@ public class Threads extends RestfulDAO<Thread> {
 		return super.list(query);
 	}
 
+	/**
+	 * Get a single thread by ID
+	 * @param id The thread ID
+	 * @return The requested thread
+	 */
 	@Override
 	public Thread get(String id) throws IOException, RequestFailedException {
+		return get(id, false);
+	}
+
+	/**
+	 * Get a single thread by ID
+	 * @param id The thread ID
+	 * @param expanded If true, the thread will return with a message and draft object as opposed to IDs
+	 * @return The requested thread
+	 */
+	public Thread get(String id, boolean expanded) throws IOException, RequestFailedException {
+		if(expanded) {
+			setView(getCollectionUrl(), "expanded");
+		}
 		return super.get(id);
 	}
 


### PR DESCRIPTION
# Description
This PR enables support for getting a message or thread by ID with an expanded view. 

# Usage
```java
NylasClient nylas = new NylasClient();
NylasAccount account = nylas.account("{ACCESS_TOKEN}");

// Get an expanded message by passing a boolean for the second parameter, indicating an expanded view
Message expandedMessage = account.messages().get("message_id", true);

// Get an expanded thread by passing a boolean for the second parameter, indicating an expanded view
Thread expandedThread = account.threads().get("thread_id", true);
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.