### PR TITLE
Fix error when updating occurrence of a recurring event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+* Fix error when updating occurrence of a recurring event
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -300,24 +300,29 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			}
 		}
 
-		List<Map<String, Object>> participantWritableFields = null;
-		if(participants != null && !participants.isEmpty()) {
-			participantWritableFields = participants.stream()
-					.map(participant -> participant.getWritableFields(creation))
-					.collect(Collectors.toList());
 		}
 
 		Maps.putIfNotNull(params, "when", getWhen());
 		Maps.putIfNotNull(params, "title", getTitle());
 		Maps.putIfNotNull(params, "description", getDescription());
 		Maps.putIfNotNull(params, "location", getLocation());
-		Maps.putIfNotNull(params, "participants", participantWritableFields);
+		Maps.putIfNotNull(params, "participants", serializeParticipants());
 		Maps.putIfNotNull(params, "busy", getBusy());
 		Maps.putIfNotNull(params, "metadata", getMetadata());
 		Maps.putIfNotNull(params, "conferencing", getConferencing());
 		Maps.putIfNotNull(params, "notifications", getNotifications());
 		Maps.putIfNotNull(params, "recurrence", getRecurrence());
 		return params;
+	}
+
+	private List<Map<String, Object>> serializeParticipants() {
+		if(this.participants == null || this.participants.isEmpty()) {
+			return null;
+		}
+
+		return this.participants.stream()
+				.map(participant -> participant.getWritableFields(false))
+				.collect(Collectors.toList());
 	}
 
 	public static class Recurrence {

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -40,6 +40,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	private List<Notification> notifications = new ArrayList<>();
 	private List<Participant> participants = new ArrayList<>();
 	private Map<String, String> metadata = new HashMap<>();
+	private final Map<String, Object> modifiedFields = new HashMap<>();
 	
 	/** for deserialization only */ public Event() {} 
 	
@@ -186,62 +187,77 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 	public void setEventCollectionId(String eventCollectionId) {
 		this.event_collection_id = eventCollectionId;
+		this.modifiedFields.put("event_collection_id", this.event_collection_id);
 	}
 
 	public void setTitle(String title) {
 		this.title = title;
+		this.modifiedFields.put("title", this.title);
 	}
 
 	public void setDescription(String description) {
 		this.description = description;
+		this.modifiedFields.put("description", this.description);
 	}
 
 	public void setWhen(When when) {
 		this.when = when;
+		this.modifiedFields.put("when", this.when);
 	}
 
 	public void setLocation(String location) {
 		this.location = location;
+		this.modifiedFields.put("location", this.location);
 	}
 
 	public void setCustomerEventId(String customerEventId) {
 		this.customer_event_id = customerEventId;
+		this.modifiedFields.put("customer_event_id", this.customer_event_id);
 	}
 
 	public void setCapacity(Integer capacity) {
 		this.capacity = capacity;
+		this.modifiedFields.put("capacity", this.capacity);
 	}
 
 	public void setParticipants(List<Participant> participants) {
 		this.participants = participants;
+		this.modifiedFields.put("participants", this.participants);
 	}
 
 	public void setBusy(Boolean busy) {
 		this.busy = busy;
+		this.modifiedFields.put("busy", this.busy);
 	}
 
 	public void setMetadata(Map<String, String> metadata) {
 		this.metadata = metadata;
+		this.modifiedFields.put("metadata", this.metadata);
 	}
 
 	public void setConferencing(Conferencing conferencing) {
 		this.conferencing = conferencing;
+		this.modifiedFields.put("conferencing", this.conferencing);
 	}
 
 	public void setRoundRobinOrder(List<String> roundRobinOrder) {
 		this.round_robin_order = roundRobinOrder;
+		this.modifiedFields.put("round_robin_order", this.round_robin_order);
 	}
 
 	public void setNotifications(List<Notification> notifications) {
 		this.notifications = notifications;
+		this.modifiedFields.put("notifications", this.notifications);
 	}
 
 	public void setRecurrence(Recurrence recurrence) {
 		this.recurrence = recurrence;
+		this.modifiedFields.put("recurrence", this.recurrence);
 	}
 
 	public void setReminders(Reminders reminders) {
 		this.reminders = reminders;
+		this.modifiedFields.put("reminders", this.reminders);
 	}
 
 	/**
@@ -251,6 +267,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	 */
 	public void addMetadata(String key, String value) {
 		this.metadata.put(key, value);
+		this.modifiedFields.put("metadata", this.metadata);
 	}
 
 	/**
@@ -262,6 +279,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 			this.notifications = new ArrayList<>();
 		}
 		this.notifications.addAll(Arrays.asList(notifications));
+		this.modifiedFields.put("notifications", this.notifications);
 	}
 
 	/**
@@ -270,6 +288,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	 */
 	public void addParticipants(Participant... participants) {
 		this.participants.addAll(Arrays.asList(participants));
+		this.modifiedFields.put("participants", serializeParticipants());
 	}
 
 	/**

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -309,18 +309,19 @@ public class Event extends AccountOwnedModel implements JsonObject {
 
 	@Override
 	protected Map<String, Object> getWritableFields(boolean creation) {
+		if (!creation) {
+			return modifiedFields;
+		}
+
 		Map<String, Object> params = new HashMap<>();
-		if (creation) {
-			Maps.putIfNotNull(params, "calendar_id", getCalendarId());
-			// Reminders, when creating an event, need to be included in the main object
-			if(reminders != null && reminders.reminder_minutes != null && reminders.reminder_method != null) {
-				params.put("reminder_minutes", String.format("[%d]", reminders.reminder_minutes));
-				params.put("reminder_method", reminders.reminder_method);
-			}
+
+		// Reminders, when creating an event, need to be included in the main object
+		if(reminders != null && reminders.reminder_minutes != null && reminders.reminder_method != null) {
+			params.put("reminder_minutes", String.format("[%d]", reminders.reminder_minutes));
+			params.put("reminder_method", reminders.reminder_method);
 		}
 
-		}
-
+		Maps.putIfNotNull(params, "calendar_id", getCalendarId());
 		Maps.putIfNotNull(params, "when", getWhen());
 		Maps.putIfNotNull(params, "title", getTitle());
 		Maps.putIfNotNull(params, "description", getDescription());


### PR DESCRIPTION
# Description
This PR fixes an issue when modifying a single instance of a recurring event. The Event object will now track all the dirty fields via a map every time a setter is invoked. Then, on save, we serialize the object using modifiedFields. 

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.