### PR TITLE
revokeAccessToken returns a boolean now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Changed
 
+* NylasAccount.revokeAccessToken() returns a boolean value now
+
 ### Deprecated
 
 ### Fixed

--- a/src/main/java/com/nylas/NylasAccount.java
+++ b/src/main/java/com/nylas/NylasAccount.java
@@ -1,6 +1,7 @@
 package com.nylas;
 
 import java.io.IOException;
+import java.util.Map;
 
 import okhttp3.HttpUrl;
 
@@ -91,10 +92,10 @@ public class NylasAccount {
 		return client.executeGet(accessToken, accountUrl, AccountDetail.class);
 	}
 
-	// TODO: Revoking an access token seems like an important op. We should return the result of the revoke operation.
-	public void revokeAccessToken() throws IOException, RequestFailedException {
+	public boolean revokeAccessToken() throws IOException, RequestFailedException {
 		HttpUrl.Builder revokeUrl = client.newUrlBuilder().addPathSegments("oauth/revoke");
-		client.executePost(accessToken, revokeUrl, null, null);
+		Map<String, Boolean> response = client.executePost(accessToken, revokeUrl, null, Map.class);
+		return response.get("success") != null && response.get("success");
 	}
 
 }

--- a/src/test/java/com/nylas/NylasAccountTest.java
+++ b/src/test/java/com/nylas/NylasAccountTest.java
@@ -5,10 +5,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 import static com.nylas.AccessTokenTest.TEST_ACCESS_TOKEN;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -61,11 +62,42 @@ public class NylasAccountTest {
     @Test
     public void testRevokeAccessToken() throws RequestFailedException, IOException {
         final NylasAccount nylasAccount = new NylasAccount(nylasClient, TEST_ACCESS_TOKEN);
+        final Map<String, Boolean> revokeResponse = Collections.singletonMap("success", true);
 
         when(nylasClient.newUrlBuilder()).thenReturn(new HttpUrl.Builder());
+        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(revokeResponse);
 
-        nylasAccount.revokeAccessToken();
+        boolean revokeAccessToken = nylasAccount.revokeAccessToken();
 
         verify(nylasClient).executePost(anyString(), any(), any(), any());
+        assertTrue(revokeAccessToken);
+    }
+
+    @Test
+    public void testRevokeAccessTokenSuccessFalse() throws RequestFailedException, IOException {
+        final NylasAccount nylasAccount = new NylasAccount(nylasClient, TEST_ACCESS_TOKEN);
+        final Map<String, Boolean> revokeResponse = Collections.singletonMap("success", false);
+
+        when(nylasClient.newUrlBuilder()).thenReturn(new HttpUrl.Builder());
+        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(revokeResponse);
+
+        boolean revokeAccessToken = nylasAccount.revokeAccessToken();
+
+        verify(nylasClient).executePost(anyString(), any(), any(), any());
+        assertFalse(revokeAccessToken);
+    }
+
+    @Test
+    public void testRevokeAccessTokenInvalidObjectReturnsFalse() throws RequestFailedException, IOException {
+        final NylasAccount nylasAccount = new NylasAccount(nylasClient, TEST_ACCESS_TOKEN);
+        final Map<String, Object> revokeResponse = Collections.singletonMap("invalidKey", "invalidValue");
+
+        when(nylasClient.newUrlBuilder()).thenReturn(new HttpUrl.Builder());
+        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(revokeResponse);
+
+        boolean revokeAccessToken = nylasAccount.revokeAccessToken();
+
+        verify(nylasClient).executePost(anyString(), any(), any(), any());
+        assertFalse(revokeAccessToken);
     }
 }


### PR DESCRIPTION
# Description
This PR changes revokeAccessToken from being a void function to returning a boolean value, allowing the user to get more information on the call they make.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.