### PR TITLE
v1.18.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+
 ## [1.18.0] - Released 2022-10-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
+## [1.18.0] - Released 2022-10-06
 
 ### Added
 
@@ -15,15 +13,9 @@ This section contains changes that have been committed but not yet released.
 
 * NylasAccount.revokeAccessToken() returns a boolean value now
 
-### Deprecated
-
 ### Fixed
 
 * Fix error when updating occurrence of a recurring event
-
-### Removed
-
-### Security
 
 ## [1.17.0] - Released 2022-09-22
 
@@ -314,7 +306,8 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.17.0...HEAD
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/nylas/nylas-java/releases/tag/v1.18.0
 [1.17.0]: https://github.com/nylas/nylas-java/releases/tag/v1.17.0
 [1.16.0]: https://github.com/nylas/nylas-java/releases/tag/v1.16.0
 [1.15.0]: https://github.com/nylas/nylas-java/releases/tag/v1.15.0

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.17.0")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.18.0")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.17.0</version>
+      <version>1.18.0</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.18.0
+version=1.19.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.18.0-SNAPSHOT
+version=1.18.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New Nylas Java SDK v1.18.0 release brings the following changes:
* Added hide participants field for the `Event` class (#103)
* Added support for provider detection (#100)
* Added an enum for all known providers for native authentication (#100)
* Improved webhook notification support with the addition of more notification attributes and event metadata fields (#102)
* NylasAccount.revokeAccessToken() returns a boolean value now (#97)
* Fix error when updating occurrence of a recurring event (#93)

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.