### PR TITLE
Add support for calendar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Add support for calendar colors (for Microsoft calendars)
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/Calendar.java
+++ b/src/main/java/com/nylas/Calendar.java
@@ -9,6 +9,7 @@ public class Calendar extends AccountOwnedModel {
 	private String description;
 	private String location;
 	private String timezone;
+	private String hex_color;
 	private Boolean read_only;
 	private Boolean is_primary;
 	private Map<String, String> metadata = new HashMap<>();
@@ -27,6 +28,10 @@ public class Calendar extends AccountOwnedModel {
 
 	public String getTimezone() {
 		return timezone;
+	}
+
+	public String getHexColor() {
+		return hex_color;
 	}
 
 	public Boolean isReadOnly() {
@@ -85,6 +90,7 @@ public class Calendar extends AccountOwnedModel {
 	@Override
 	public String toString() {
 		return "Calendar [name=" + name + ", description=" + description + ", location=" + location + ", timezone="
-				+ timezone + ", readOnly=" + read_only + ", isPrimary=" + is_primary + ", metadata=" + metadata + "]";
+				+ timezone + ", hexColor=" + hex_color + ", readOnly=" + read_only + ", isPrimary=" + is_primary
+				+ ", metadata=" + metadata + "]";
 	}
 }


### PR DESCRIPTION
# Description
This PR adds support for the new colors field in the Calendar model. Please note that this field is read only, and for Microsoft calendars only.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.