### PR TITLE
Fixed revoke access token always throwing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+* Fixed revoke access token always throwing an error
+
 ### Removed
 
 ### Security

--- a/src/main/java/com/nylas/NylasAccount.java
+++ b/src/main/java/com/nylas/NylasAccount.java
@@ -94,8 +94,8 @@ public class NylasAccount {
 
 	public boolean revokeAccessToken() throws IOException, RequestFailedException {
 		HttpUrl.Builder revokeUrl = client.newUrlBuilder().addPathSegments("oauth/revoke");
-		Map<String, Boolean> response = client.executePost(accessToken, revokeUrl, null, Map.class);
-		return response.get("success") != null && response.get("success");
+		client.executePost(accessToken, revokeUrl, null, null);
+		return true;
 	}
 
 }

--- a/src/test/java/com/nylas/NylasAccountTest.java
+++ b/src/test/java/com/nylas/NylasAccountTest.java
@@ -71,18 +71,4 @@ public class NylasAccountTest {
         verify(nylasClient).executePost(anyString(), any(), any(), any());
         assertTrue(revokeAccessToken);
     }
-
-    @Test
-    public void testRevokeAccessTokenInvalidObjectReturnsFalse() throws RequestFailedException, IOException {
-        final NylasAccount nylasAccount = new NylasAccount(nylasClient, TEST_ACCESS_TOKEN);
-        final Map<String, Object> revokeResponse = Collections.singletonMap("invalidKey", "invalidValue");
-
-        when(nylasClient.newUrlBuilder()).thenReturn(new HttpUrl.Builder());
-        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(revokeResponse);
-
-        boolean revokeAccessToken = nylasAccount.revokeAccessToken();
-
-        verify(nylasClient).executePost(anyString(), any(), any(), any());
-        assertFalse(revokeAccessToken);
-    }
 }

--- a/src/test/java/com/nylas/NylasAccountTest.java
+++ b/src/test/java/com/nylas/NylasAccountTest.java
@@ -62,29 +62,14 @@ public class NylasAccountTest {
     @Test
     public void testRevokeAccessToken() throws RequestFailedException, IOException {
         final NylasAccount nylasAccount = new NylasAccount(nylasClient, TEST_ACCESS_TOKEN);
-        final Map<String, Boolean> revokeResponse = Collections.singletonMap("success", true);
 
         when(nylasClient.newUrlBuilder()).thenReturn(new HttpUrl.Builder());
-        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(revokeResponse);
+        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(null);
 
         boolean revokeAccessToken = nylasAccount.revokeAccessToken();
 
         verify(nylasClient).executePost(anyString(), any(), any(), any());
         assertTrue(revokeAccessToken);
-    }
-
-    @Test
-    public void testRevokeAccessTokenSuccessFalse() throws RequestFailedException, IOException {
-        final NylasAccount nylasAccount = new NylasAccount(nylasClient, TEST_ACCESS_TOKEN);
-        final Map<String, Boolean> revokeResponse = Collections.singletonMap("success", false);
-
-        when(nylasClient.newUrlBuilder()).thenReturn(new HttpUrl.Builder());
-        when(nylasClient.executePost(anyString(), any(), any(), any())).thenReturn(revokeResponse);
-
-        boolean revokeAccessToken = nylasAccount.revokeAccessToken();
-
-        verify(nylasClient).executePost(anyString(), any(), any(), any());
-        assertFalse(revokeAccessToken);
     }
 
     @Test


### PR DESCRIPTION
# Description
This PR fixes the error that always returns when revoking an access token. The SDK attempts to deserialize the response from the API, but the API just returns a 200 with no body.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.