### PR TITLE
Add Rate Limit error support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This section contains changes that have been committed but not yet released.
 ### Added
 
 * Add support for calendar colors (for Microsoft calendars)
+* Added support for rate limit errors
 
 ### Changed
 

--- a/src/main/java/com/nylas/NylasClient.java
+++ b/src/main/java/com/nylas/NylasClient.java
@@ -252,6 +252,12 @@ public class NylasClient {
 		if (!response.isSuccessful()) {
 			String responseBody = response.body().string();
 			response.close();
+			if(response.code() == RateLimitException.RATE_LIMIT_STATUS_CODE) {
+				String rateLimit = response.headers().get(RateLimitException.RATE_LIMIT_LIMIT_HEADER);
+				String rateLimitReset = response.headers().get(RateLimitException.RATE_LIMIT_RESET_HEADER);
+				throw RateLimitException.parseErrorResponse(rateLimit, rateLimitReset, responseBody);
+			}
+
 			throw RequestFailedException.parseErrorResponse(response.code(), responseBody);
 		}
 	}

--- a/src/main/java/com/nylas/RateLimitException.java
+++ b/src/main/java/com/nylas/RateLimitException.java
@@ -1,0 +1,75 @@
+package com.nylas;
+
+import java.util.Map;
+
+/**
+ * This exception represents a 429 error response, with details on the rate limit
+ */
+public class RateLimitException extends RequestFailedException {
+
+	public static final int RATE_LIMIT_STATUS_CODE = 429;
+	public static final String RATE_LIMIT_LIMIT_HEADER = "X-RateLimit-Limit";
+	public static final String RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset";
+
+	/**
+	 * The rate limit
+	 */
+	private final int rateLimit;
+	/**
+	 * The rate limit expiration time, in seconds
+	 */
+	private final int rateLimitReset;
+
+	public RateLimitException(String errorMessage, String errorType, int rateLimit, int rateLimitReset) {
+		super(RATE_LIMIT_STATUS_CODE, errorMessage, errorType);
+		this.rateLimit = rateLimit;
+		this.rateLimitReset = rateLimitReset;
+	}
+
+	public int getRateLimit() {
+		return rateLimit;
+	}
+
+	public int getRateLimitReset() {
+		return rateLimitReset;
+	}
+
+	/**
+	 * Creates an error response
+	 * @param rateLimitHeader The header value of the rate limit
+	 * @param rateLimitResetHeader The header value of the rate limit reset
+	 * @param responseBody The error payload to parse details from
+	 * @return The error with all the rate limit details
+	 */
+	public static RateLimitException parseErrorResponse(String rateLimitHeader, String rateLimitResetHeader, String responseBody) {
+		String errorMessage = null;
+		String errorType = null;
+		int rateLimit = 0;
+		int rateLimitReset = 0;
+		if (responseBody != null && responseBody.length() > 0) {
+			try {
+				Map<String, Object> responseFields = JsonHelper.jsonToMap(responseBody);
+				errorMessage = (String) responseFields.get("message");
+				errorType = (String) responseFields.get("type");
+			} catch (Throwable t) {
+				// swallow
+			}
+		}
+		try {
+			rateLimit = Integer.parseInt(rateLimitHeader);
+		} catch (NumberFormatException e) {
+			// swallow
+		}
+		try {
+			rateLimitReset = Integer.parseInt(rateLimitResetHeader);
+		} catch (NumberFormatException e) {
+			// swallow
+		}
+		return new RateLimitException(errorMessage, errorType, rateLimit, rateLimitReset);
+	}
+
+	@Override
+	public String toString() {
+		return "com.nylas.RateLimitException [" + formatError(getStatusCode(), getErrorType(), getErrorMessage()) + "]";
+	}
+}

--- a/src/main/java/com/nylas/RequestFailedException.java
+++ b/src/main/java/com/nylas/RequestFailedException.java
@@ -84,7 +84,7 @@ public class RequestFailedException extends Exception {
 		return new RequestFailedException(statusCode, errorMessage, errorType);
 	}
 
-	private static String formatError(int statusCode, String type, String message) {
+	protected static String formatError(int statusCode, String type, String message) {
 		return "statusCode=" + statusCode + ", type=" + type + ", message=" + message;
 	}
 	

--- a/src/main/java/com/nylas/RequestFailedException.java
+++ b/src/main/java/com/nylas/RequestFailedException.java
@@ -7,8 +7,17 @@ import java.util.Map;
  */
 public class RequestFailedException extends Exception {
 
+	/**
+	 * The status code returned from the API
+	 */
 	private final int statusCode;
+	/**
+	 * The error message returned from the Nylas API payload
+	 */
 	private final String errorMessage;
+	/**
+	 * The type of error returned from the Nylas API payload
+	 */
 	private final String errorType;
 	
 	public RequestFailedException(int statusCode, String errorMessage, String errorType) {
@@ -69,6 +78,12 @@ public class RequestFailedException extends Exception {
 		return errorType;
 	}
 
+	/**
+	 * Creates an error response
+	 * @param statusCode The status code returned from the API
+	 * @param responseBody The error payload to parse details from
+	 * @return The error with the details from the API
+	 */
 	public static RequestFailedException parseErrorResponse(int statusCode, String responseBody) {
 		String errorMessage = null;
 		String errorType = null;


### PR DESCRIPTION
# Description
This PR adds support for rate limit 429 headers from the API.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.