### PR TITLE
Pass PUT/POST state when serializing participants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This section contains changes that have been committed but not yet released.
 ### Fixed
 
 * Fixed revoke access token always throwing an error
+* Fixed participant status not serializing on Event creation
 
 ### Removed
 

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -312,7 +312,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 	 */
 	public void addParticipants(Participant... participants) {
 		this.participants.addAll(Arrays.asList(participants));
-		this.modifiedFields.put("participants", serializeParticipants());
+		this.modifiedFields.put("participants", serializeParticipants(false));
 	}
 
 	/**
@@ -357,7 +357,7 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		Maps.putIfNotNull(params, "title", getTitle());
 		Maps.putIfNotNull(params, "description", getDescription());
 		Maps.putIfNotNull(params, "location", getLocation());
-		Maps.putIfNotNull(params, "participants", serializeParticipants());
+		Maps.putIfNotNull(params, "participants", serializeParticipants(true));
 		Maps.putIfNotNull(params, "busy", getBusy());
 		Maps.putIfNotNull(params, "metadata", getMetadata());
 		Maps.putIfNotNull(params, "conferencing", getConferencing());
@@ -366,13 +366,13 @@ public class Event extends AccountOwnedModel implements JsonObject {
 		return params;
 	}
 
-	private List<Map<String, Object>> serializeParticipants() {
+	private List<Map<String, Object>> serializeParticipants(boolean creation) {
 		if(this.participants == null || this.participants.isEmpty()) {
 			return Collections.emptyList();
 		}
 
 		return this.participants.stream()
-				.map(participant -> participant.getWritableFields(false))
+				.map(participant -> participant.getWritableFields(creation))
 				.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
# Description
This PR fixes the SDK not serializing participant status on Event creation.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.