### PR TITLE
Middleware infrastructure for use cases and local webhook support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // Middleware-related dependencies
     implementation('javax.servlet:javax.servlet-api:3.0.1')
+    implementation('org.java-websocket:Java-WebSocket:1.5.3')
 
     ///////////////////////////////////
     // Test dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,10 @@ dependencies {
     
     // SLF4J for logging facade
     implementation('org.slf4j:slf4j-api:1.7.30')
-    
+
+    // Middleware-related dependencies
+    implementation('javax.servlet:javax.servlet-api:3.0.1')
+
     ///////////////////////////////////
     // Test dependencies
     

--- a/src/main/java/com/nylas/Notification.java
+++ b/src/main/java/com/nylas/Notification.java
@@ -19,6 +19,13 @@ import com.squareup.moshi.JsonReader;
 
 public class Notification {
 
+	/**
+	 * Verify incoming signature came from Nylas
+	 * @param jsonNotification The notification body
+	 * @param clientSecret The client secret belonging to the notification, to verify the signature with
+	 * @param expectedSignature The signature to verify
+	 * @return True if the signature is indeed from Nylas
+	 */
 	public static boolean isSignatureValid(String jsonNotification, String clientSecret, String expectedSignature) {
 		try {
 			byte[] expectedBytes = hexStringToByteArray(expectedSignature);

--- a/src/main/java/com/nylas/Notification.java
+++ b/src/main/java/com/nylas/Notification.java
@@ -40,6 +40,7 @@ public class Notification {
 		}
 	}
 	
+	public static final String NYLAS_SIGNATURE_HEADER = "X-Nylas-Signature";
 	private static final JsonAdapter<Notification> JSON_ADAPTER =  JsonHelper.moshi().adapter(Notification.class);
 	public static Notification parseNotification(String jsonNotification) {
 		return JsonHelper.fromJsonUnchecked(JSON_ADAPTER, jsonNotification);

--- a/src/main/java/com/nylas/Webhook.java
+++ b/src/main/java/com/nylas/Webhook.java
@@ -3,6 +3,8 @@ package com.nylas;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Webhook extends RestfulModel {
 
@@ -11,6 +13,49 @@ public class Webhook extends RestfulModel {
 	private String state;
 	private List<String> triggers;
 	private String version;
+
+	/**
+	 * Enumeration containing the different webhook triggers
+	 */
+	public enum Trigger {
+		AccountConnected("account.connected"),
+		AccountRunning("account.running"),
+		AccountStopped("account.stopped"),
+		AccountInvalid("account.invalid"),
+		AccountSyncError("account.sync_error"),
+		MessageBounced("message.bounced"),
+		MessageCreated("message.created"),
+		MessageOpened("message.opened"),
+		MessageUpdated("message.updated"),
+		MessageLinkClicked("message.link_clicked"),
+		ThreadReplied("thread.replied"),
+		ContactCreated("contact.created"),
+		ContactUpdated("contact.updated"),
+		ContactDeleted("contact.deleted"),
+		CalendarCreated("calendar.created"),
+		CalendarUpdated("calendar.updated"),
+		CalendarDeleted("calendar.deleted"),
+		EventCreated("event.created"),
+		EventUpdated("event.updated"),
+		EventDeleted("event.deleted"),
+		JobSuccessful("job.successful"),
+		JobFailed("job.failed");
+
+		private final String name;
+
+		Trigger(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	public enum State {
+		ACTIVE,
+		INACTIVE;
+	}
 	
 	public String getApplicationId() {
 		return application_id;
@@ -40,8 +85,18 @@ public class Webhook extends RestfulModel {
 		this.state = state;
 	}
 
+	public void setState(State state) {
+		this.state = state.toString().toLowerCase();
+	}
+
 	public void setTriggers(List<String> triggers) {
 		this.triggers = triggers;
+	}
+
+	public void setTriggers(Trigger... triggers) {
+		this.triggers = Stream.of(triggers)
+				.map(Trigger::name)
+				.collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/com/nylas/server_bindings/ExchangeMailboxTokenCallback.java
+++ b/src/main/java/com/nylas/server_bindings/ExchangeMailboxTokenCallback.java
@@ -1,0 +1,29 @@
+package com.nylas.server_bindings;
+
+import com.nylas.AccessToken;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Interface for classes to implement callbacks for exchanging a code for a token.
+ * See: {@link NylasFilter}
+ */
+public interface ExchangeMailboxTokenCallback {
+
+	/**
+	 * Callback invoked after a successful token exchange
+	 * @param request Incoming request data
+	 * @param response Response object that can be written to
+	 * @param accessToken The object containing the access token
+	 */
+	void onTokenExchange(HttpServletRequest request, HttpServletResponse response, AccessToken accessToken);
+
+	/**
+	 * Callback invoked after an error encountered during the token exchange
+	 * @param request Incoming request data
+	 * @param response Response object that can be written to
+	 * @param error The error object
+	 */
+	void onTokenExchangeError(HttpServletRequest request, HttpServletResponse response, Exception error);
+}

--- a/src/main/java/com/nylas/server_bindings/NylasFilter.java
+++ b/src/main/java/com/nylas/server_bindings/NylasFilter.java
@@ -9,6 +9,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -17,23 +18,27 @@ import java.util.stream.Collectors;
  * Nylas functionality such as authentication. Currently supported routes are:
  *
  * <br> 1. '/nylas/generate-auth-url': Building the URL for authenticating users to
- * your application via Hosted Authentication
+ * 		your application via Hosted Authentication
  * <br> 2. '/nylas/exchange-mailbox-token': Exchange an authorization code for an access token
+ * <br> 3. '/nylas/webhook': Verifies incoming webhook authenticity, parses it as an object,
+ * 			then can pass it to a callback function (if set)
  */
 public class NylasFilter implements Filter {
 	private final Routes routes;
 	private final Scope[] defaultScopes;
 	private final ExchangeMailboxTokenCallback exchangeMailboxTokenCallback;
+	private WebhookNotificationCallback webhookNotificationCallback;
 	private String clientUri;
 	private String buildAuthUrl = Routes.Constants.BUILD_AUTH_URL;
 	private String exchangeCodeForTokenUrl = Routes.Constants.EXCHANGE_CODE_FOR_TOKEN;
+	private String webhooksUrl = Routes.Constants.WEBHOOKS;
 	private static final Logger LOGGER = LoggerFactory.getLogger(NylasFilter.class);
 
 	/**
 	 * Constructor for NylasFilter
 	 * @param nylasApplication The configured Nylas application
 	 * @param defaultScopes The authentication scopes to request from the authenticating user
-	 * @param exchangeMailboxTokenCallback A class configured with methods to handle a callback after exchanging token
+	 * @param exchangeMailboxTokenCallback A class configured with a callback after exchanging token
 	 */
 	public NylasFilter(
 			NylasApplication nylasApplication,
@@ -54,6 +59,14 @@ public class NylasFilter implements Filter {
 	}
 
 	/**
+	 * Set the class responsible for processing webhook notifications
+	 * @param webhookNotificationCallback class configured with a callback after receiving a webhook notification
+	 */
+	public void setWebhookNotificationCallback(WebhookNotificationCallback webhookNotificationCallback) {
+		this.webhookNotificationCallback = webhookNotificationCallback;
+	}
+
+	/**
 	 * Override the serving path of the buildAuthUrl endpoint.
 	 * Defaults to {@value Routes.Constants#BUILD_AUTH_URL}
 	 * @param buildAuthUrl The new path to set buildAuthUrl to
@@ -69,6 +82,15 @@ public class NylasFilter implements Filter {
 	 */
 	public void overrideExchangeCodeForToken(String exchangeCodeForTokenUrl) {
 		this.exchangeCodeForTokenUrl = exchangeCodeForTokenUrl;
+	}
+
+	/**
+	 * Override the serving path of the webhooks endpoint.
+	 * Defaults to {@value Routes.Constants#WEBHOOKS}
+	 * @param webhooksUrl The new path to set webhooks to
+	 */
+	public void overrideWebhooksUrl(String webhooksUrl) {
+		this.webhooksUrl = webhooksUrl;
 	}
 
 	@Override
@@ -91,6 +113,8 @@ public class NylasFilter implements Filter {
 				} catch (RequestFailedException e) {
 					this.exchangeMailboxTokenCallback.onTokenExchangeError(httpServletRequest, httpServletResponse, e);
 				}
+			} else if(requestURI.equals(this.webhooksUrl)) {
+				handeWebhooks(httpServletRequest, httpServletResponse);
 			} else {
 				chain.doFilter(request, response);
 			}
@@ -113,11 +137,41 @@ public class NylasFilter implements Filter {
 		response.setStatus(200);
 	}
 
-	private void handleExchangeCodeForToken(HttpServletRequest request, HttpServletResponse response) throws IOException, RequestFailedException {
+	private void handleExchangeCodeForToken(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, RequestFailedException {
 		Map<String, Object> json = parseRequestBody(request);
 		String token = (String) json.get("token");
 		AccessToken accessToken = this.routes.exchangeCodeForToken(token);
 		this.exchangeMailboxTokenCallback.onTokenExchange(request, response, accessToken);
+	}
+
+	private void handeWebhooks(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String jsonString = request.getReader().lines().collect(Collectors.joining (System.lineSeparator()));
+		String nylasSignatureHeader = request.getHeader(Notification.NYLAS_SIGNATURE_HEADER);
+		if(nylasSignatureHeader != null && this.routes.verifyWebhookSignature(nylasSignatureHeader, jsonString)) {
+			if(webhookNotificationCallback != null) {
+				Notification parsedNotification = Notification.parseNotification(jsonString);
+				webhookNotificationCallback.onNotification(request, response, parsedNotification);
+			} else {
+				response.getWriter().write(jsonString);
+				response.setContentType("application/json");
+				response.setStatus(200);
+			}
+		} else {
+			if(webhookNotificationCallback != null) {
+				webhookNotificationCallback.onUnverifiedNotification(request, response);
+			} else {
+				String errorMessage = String.format(
+						"Webhook notification received but was not verified. %s value: %s",
+						Notification.NYLAS_SIGNATURE_HEADER,
+						nylasSignatureHeader
+				);
+				Map<String, Object> errorResponse = Collections.singletonMap("error", errorMessage);
+				response.getWriter().write(JsonHelper.mapToJson(errorResponse));
+				response.setContentType("application/json");
+				response.setStatus(400);
+			}
+		}
 	}
 
 	private Map<String, Object> parseRequestBody(HttpServletRequest request) throws IOException {

--- a/src/main/java/com/nylas/server_bindings/NylasFilter.java
+++ b/src/main/java/com/nylas/server_bindings/NylasFilter.java
@@ -32,7 +32,7 @@ public class NylasFilter implements Filter {
 	private String buildAuthUrl = Routes.Constants.BUILD_AUTH_URL;
 	private String exchangeCodeForTokenUrl = Routes.Constants.EXCHANGE_CODE_FOR_TOKEN;
 	private String webhooksUrl = Routes.Constants.WEBHOOKS;
-	private static final Logger LOGGER = LoggerFactory.getLogger(NylasFilter.class);
+	private static final Logger log = LoggerFactory.getLogger(NylasFilter.class);
 
 	/**
 	 * Constructor for NylasFilter
@@ -95,7 +95,7 @@ public class NylasFilter implements Filter {
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
-		LOGGER.trace("Setting up the Nylas Filter");
+		log.trace("Setting up the Nylas Filter");
 	}
 
 	@Override
@@ -125,7 +125,7 @@ public class NylasFilter implements Filter {
 
 	@Override
 	public void destroy() {
-		LOGGER.trace("Destroying the Nylas Filter");
+		log.trace("Destroying the Nylas Filter");
 	}
 
 	private void handleBuildAuthUrl(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/com/nylas/server_bindings/NylasFilter.java
+++ b/src/main/java/com/nylas/server_bindings/NylasFilter.java
@@ -1,0 +1,127 @@
+package com.nylas.server_bindings;
+
+import com.nylas.*;
+import com.nylas.services.Routes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A filter for backed frameworks that enables seamless integration with useful
+ * Nylas functionality such as authentication. Currently supported routes are:
+ *
+ * <br> 1. '/nylas/generate-auth-url': Building the URL for authenticating users to
+ * your application via Hosted Authentication
+ * <br> 2. '/nylas/exchange-mailbox-token': Exchange an authorization code for an access token
+ */
+public class NylasFilter implements Filter {
+	private final Routes routes;
+	private final Scope[] defaultScopes;
+	private final ExchangeMailboxTokenCallback exchangeMailboxTokenCallback;
+	private String clientUri;
+	private String buildAuthUrl = Routes.Constants.BUILD_AUTH_URL;
+	private String exchangeCodeForTokenUrl = Routes.Constants.EXCHANGE_CODE_FOR_TOKEN;
+	private static final Logger LOGGER = LoggerFactory.getLogger(NylasFilter.class);
+
+	/**
+	 * Constructor for NylasFilter
+	 * @param nylasApplication The configured Nylas application
+	 * @param defaultScopes The authentication scopes to request from the authenticating user
+	 * @param exchangeMailboxTokenCallback A class configured with methods to handle a callback after exchanging token
+	 */
+	public NylasFilter(
+			NylasApplication nylasApplication,
+			Scope[] defaultScopes,
+			ExchangeMailboxTokenCallback exchangeMailboxTokenCallback
+	) {
+		this.routes = new Routes(nylasApplication);
+		this.defaultScopes = defaultScopes;
+		this.exchangeMailboxTokenCallback = exchangeMailboxTokenCallback;
+	}
+
+	/**
+	 * Set the base route for the client
+	 * @param clientUri The route of the client
+	 */
+	public void setClientUri(String clientUri) {
+		this.clientUri = clientUri;
+	}
+
+	/**
+	 * Override the serving path of the buildAuthUrl endpoint.
+	 * Defaults to {@value Routes.Constants#BUILD_AUTH_URL}
+	 * @param buildAuthUrl The new path to set buildAuthUrl to
+	 */
+	public void overrideBuildAuthUrl(String buildAuthUrl) {
+		this.buildAuthUrl = buildAuthUrl;
+	}
+
+	/**
+	 * Override the serving path of the exchangeCodeForToken endpoint.
+	 * Defaults to {@value Routes.Constants#EXCHANGE_CODE_FOR_TOKEN}
+	 * @param exchangeCodeForTokenUrl The new path to set exchangeCodeForToken to
+	 */
+	public void overrideExchangeCodeForToken(String exchangeCodeForTokenUrl) {
+		this.exchangeCodeForTokenUrl = exchangeCodeForTokenUrl;
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		LOGGER.trace("Setting up the Nylas Filter");
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+		String requestURI = httpServletRequest.getRequestURI();
+		if(httpServletRequest.getMethod().equals("POST")) {
+			if(requestURI.equals(this.buildAuthUrl)) {
+				handleBuildAuthUrl(httpServletRequest, httpServletResponse);
+			} else if(requestURI.equals(this.exchangeCodeForTokenUrl)) {
+				try {
+					handleExchangeCodeForToken(httpServletRequest, httpServletResponse);
+				} catch (RequestFailedException e) {
+					this.exchangeMailboxTokenCallback.onTokenExchangeError(httpServletRequest, httpServletResponse, e);
+				}
+			} else {
+				chain.doFilter(request, response);
+			}
+		} else {
+			chain.doFilter(request, response);
+		}
+	}
+
+	@Override
+	public void destroy() {
+		LOGGER.trace("Destroying the Nylas Filter");
+	}
+
+	private void handleBuildAuthUrl(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		Map<String, Object> json = parseRequestBody(request);
+		String emailAddress = (String) json.get("email_address");
+		String successUrl = (String) json.get("success_url");
+		String authUrl = this.routes.buildAuthUrl(defaultScopes, emailAddress, successUrl, this.clientUri, null);
+		response.getWriter().write(authUrl);
+		response.setStatus(200);
+	}
+
+	private void handleExchangeCodeForToken(HttpServletRequest request, HttpServletResponse response) throws IOException, RequestFailedException {
+		Map<String, Object> json = parseRequestBody(request);
+		String token = (String) json.get("token");
+		AccessToken accessToken = this.routes.exchangeCodeForToken(token);
+		this.exchangeMailboxTokenCallback.onTokenExchange(request, response, accessToken);
+	}
+
+	private Map<String, Object> parseRequestBody(HttpServletRequest request) throws IOException {
+		String json = request.getReader().lines().collect(Collectors.joining (System.lineSeparator()));
+		return JsonHelper.jsonToMap(json);
+	}
+}

--- a/src/main/java/com/nylas/server_bindings/WebhookNotificationCallback.java
+++ b/src/main/java/com/nylas/server_bindings/WebhookNotificationCallback.java
@@ -1,0 +1,24 @@
+package com.nylas.server_bindings;
+
+import com.nylas.Notification;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public interface WebhookNotificationCallback {
+
+	/**
+	 * Callback invoked after a webhook notification was received
+	 * @param request Incoming request data
+	 * @param response Response object that can be written to
+	 * @param webhookNotification The parsed notification
+	 */
+	void onNotification(HttpServletRequest request, HttpServletResponse response, Notification webhookNotification);
+
+	/**
+	 * Callback invoked after a webhook notification was received, but was not able to be verified from Nylas
+	 * @param request Incoming request data
+	 * @param response Response object that can be written to
+	 */
+	void onUnverifiedNotification(HttpServletRequest request, HttpServletResponse response);
+}

--- a/src/main/java/com/nylas/server_bindings/WebhookTunnel.java
+++ b/src/main/java/com/nylas/server_bindings/WebhookTunnel.java
@@ -13,6 +13,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Sets up and registers a websocket connection for local webhook testing
+ */
 public class WebhookTunnel extends WebSocketClient {
 
 	private final NylasApplication app;
@@ -34,6 +37,10 @@ public class WebhookTunnel extends WebSocketClient {
 		this.setHeaders();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Also registers the webhook with the Nylas API.
+	 */
 	@Override
 	public void connect() {
 		super.connect();
@@ -45,12 +52,20 @@ public class WebhookTunnel extends WebSocketClient {
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Calls {@link WebhookHandler#onOpen(short)}
+	 */
 	@Override
 	public void onOpen(ServerHandshake handshakedata) {
 		log.trace("Opening websocket connection");
 		webhookHandler.onOpen(handshakedata.getHttpStatus());
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Calls {@link WebhookHandler#onMessage(Notification)}
+	 */
 	@Override
 	public void onMessage(String message) {
 		log.trace("Messaged received from websocket");
@@ -63,18 +78,29 @@ public class WebhookTunnel extends WebSocketClient {
 		log.trace("Not a valid delta response, skipping.");
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Calls {@link WebhookHandler#onClose(int, String, boolean)}
+	 */
 	@Override
 	public void onClose(int code, String reason, boolean remote) {
 		log.trace("Closing websocket connection");
 		webhookHandler.onClose(code, reason, remote);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Calls {@link WebhookHandler#onError(Exception)}
+	 */
 	@Override
 	public void onError(Exception ex) {
 		log.trace("Error encountered during websocket connection");
 		webhookHandler.onError(ex);
 	}
 
+	/**
+	 * Sets the headers necessary for setting up the websocket tunnel
+ 	 */
 	private void setHeaders() {
 		this.addHeader("Client-Id", app.getClientId());
 		this.addHeader("Client-Secret", app.getClientSecret());
@@ -82,6 +108,12 @@ public class WebhookTunnel extends WebSocketClient {
 		this.addHeader("Region", region);
 	}
 
+	/**
+	 * Registers the websocket connection and the callback with your Nylas application
+	 * @param app The configured Nylas application
+	 * @param tunnelId The UUID generated for the websocket tunnel
+	 * @param triggers The triggers to subscribe to
+	 */
 	private void registerWebhookCallback(NylasApplication app, String tunnelId, List<String> triggers)
 			throws RequestFailedException, IOException {
 		Webhook webhook = new Webhook();
@@ -91,38 +123,63 @@ public class WebhookTunnel extends WebSocketClient {
 		app.webhooks().create(webhook);
 	}
 
+	/**
+	 * A builder for {@link WebhookTunnel}
+	 */
 	public static class Builder {
 		private final NylasApplication app;
 		private final WebhookHandler webhookHandler;
 		private String region = "us";
-		private List<String> triggers = convertScopesToString(Webhook.Trigger.values());
+		private List<String> triggers = convertTriggersToString(Webhook.Trigger.values());
 
 		public Builder(NylasApplication app, WebhookHandler webhookHandler) {
 			this.app = app;
 			this.webhookHandler = webhookHandler;
 		}
 
+		/**
+		 * Set the region to configure the websocket to
+		 * @param region The Nylas region
+		 * @return The builder with the region set
+		 */
 		public Builder region(String region) {
 			this.region = region;
 			return this;
 		}
 
+		/**
+		 * Set the webhook trigger(s) to subscribe to
+		 * @param triggers The webhook trigger(s) to subscribe to
+		 * @return The builder with the trigger(s) set
+		 */
 		public Builder triggers(Webhook.Trigger... triggers) {
-			this.triggers = convertScopesToString(triggers);
+			this.triggers = convertTriggersToString(triggers);
 			return this;
 		}
 
+		/**
+		 * Builds the WebhookTunnel
+		 * @return The configured WebhookTunnel
+		 */
 		public WebhookTunnel build() throws URISyntaxException {
 			return new WebhookTunnel(this);
 		}
 
-		private static List<String> convertScopesToString(Webhook.Trigger[] triggers) {
+		/**
+		 * Helper method that converts a list of triggers to their string values
+		 * @param triggers The list of triggers to convert
+		 * @return A list of strings with the value of the provided triggers
+		 */
+		private static List<String> convertTriggersToString(Webhook.Trigger[] triggers) {
 			return Stream.of(triggers)
 					.map(Webhook.Trigger::getName)
 					.collect(Collectors.toList());
 		}
 	}
 
+	/**
+	 * An interface for implementing classes to handle events from the {@link WebhookTunnel}
+	 */
 	public interface WebhookHandler {
 		void onOpen(short httpStatusCode);
 		void onClose(int code, String reason, boolean remote);

--- a/src/main/java/com/nylas/server_bindings/WebhookTunnel.java
+++ b/src/main/java/com/nylas/server_bindings/WebhookTunnel.java
@@ -1,0 +1,132 @@
+package com.nylas.server_bindings;
+
+import com.nylas.*;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class WebhookTunnel extends WebSocketClient {
+
+	private final NylasApplication app;
+	private final String tunnelId;
+	private final WebhookHandler webhookHandler;
+	private final List<String> triggers;
+	private final String region;
+	private static final String websocketDomain = "tunnel.nylas.com";
+	private static final String callbackDomain = "cb.nylas.com";
+	private static final Logger log = LoggerFactory.getLogger(WebhookTunnel.class);
+
+	public WebhookTunnel(Builder builder) throws URISyntaxException {
+		super(new URI("wss://" + websocketDomain));
+		this.webhookHandler = builder.webhookHandler;
+		this.app = builder.app;
+		this.tunnelId = UUID.randomUUID().toString();
+		this.triggers = builder.triggers;
+		this.region = builder.region;
+		this.setHeaders();
+	}
+
+	@Override
+	public void connect() {
+		super.connect();
+		try {
+			registerWebhookCallback(app, tunnelId, triggers);
+		} catch (RequestFailedException | IOException e) {
+			log.trace("Error encountered while trying to register webhook with the Nylas API");
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void onOpen(ServerHandshake handshakedata) {
+		log.trace("Opening websocket connection");
+		webhookHandler.onOpen(handshakedata.getHttpStatus());
+	}
+
+	@Override
+	public void onMessage(String message) {
+		log.trace("Messaged received from websocket");
+		Map<String, Object> response = JsonHelper.jsonToMap(message);
+		String jsonBody = (String) response.get("body");
+		if(jsonBody != null) {
+			Notification notification = Notification.parseNotification(jsonBody);
+			webhookHandler.onMessage(notification);
+		}
+		log.trace("Not a valid delta response, skipping.");
+	}
+
+	@Override
+	public void onClose(int code, String reason, boolean remote) {
+		log.trace("Closing websocket connection");
+		webhookHandler.onClose(code, reason, remote);
+	}
+
+	@Override
+	public void onError(Exception ex) {
+		log.trace("Error encountered during websocket connection");
+		webhookHandler.onError(ex);
+	}
+
+	private void setHeaders() {
+		this.addHeader("Client-Id", app.getClientId());
+		this.addHeader("Client-Secret", app.getClientSecret());
+		this.addHeader("Tunnel-Id", tunnelId);
+		this.addHeader("Region", region);
+	}
+
+	private void registerWebhookCallback(NylasApplication app, String tunnelId, List<String> triggers)
+			throws RequestFailedException, IOException {
+		Webhook webhook = new Webhook();
+		webhook.setCallbackUrl(String.format("https://%s/%s", callbackDomain, tunnelId));
+		webhook.setState(Webhook.State.ACTIVE);
+		webhook.setTriggers(triggers);
+		app.webhooks().create(webhook);
+	}
+
+	public static class Builder {
+		private final NylasApplication app;
+		private final WebhookHandler webhookHandler;
+		private String region = "us";
+		private List<String> triggers = convertScopesToString(Webhook.Trigger.values());
+
+		public Builder(NylasApplication app, WebhookHandler webhookHandler) {
+			this.app = app;
+			this.webhookHandler = webhookHandler;
+		}
+
+		public Builder region(String region) {
+			this.region = region;
+			return this;
+		}
+
+		public Builder triggers(Webhook.Trigger... triggers) {
+			this.triggers = convertScopesToString(triggers);
+			return this;
+		}
+
+		public WebhookTunnel build() throws URISyntaxException {
+			return new WebhookTunnel(this);
+		}
+
+		private static List<String> convertScopesToString(Webhook.Trigger[] triggers) {
+			return Stream.of(triggers)
+					.map(Webhook.Trigger::getName)
+					.collect(Collectors.toList());
+		}
+	}
+
+	public interface WebhookHandler {
+		void onOpen(short httpStatusCode);
+		void onClose(int code, String reason, boolean remote);
+		void onMessage(Notification notification);
+		void onError(Exception ex);
+	}
+}

--- a/src/main/java/com/nylas/services/Routes.java
+++ b/src/main/java/com/nylas/services/Routes.java
@@ -1,7 +1,6 @@
 package com.nylas.services;
 
 import com.nylas.*;
-import com.sun.istack.internal.Nullable;
 
 import java.io.IOException;
 
@@ -20,6 +19,22 @@ public class Routes {
 	 * @param scopes Authentication scopes to request from the authenticating user
 	 * @param emailAddress The user's email address
 	 * @param successUrl The URI to which the user will be redirected once authentication completes
+	 * {@code clientUri} and {@code state} are set to null.
+	 * @return The URL for hosted authentication
+	 */
+	public String buildAuthUrl(
+			Scope[] scopes,
+			String emailAddress,
+			String successUrl
+	) {
+		return buildAuthUrl(scopes, emailAddress, successUrl, null, null);
+	}
+
+	/**
+	 * Build the URL for authenticating users to your application via Hosted Authentication
+	 * @param scopes Authentication scopes to request from the authenticating user
+	 * @param emailAddress The user's email address
+	 * @param successUrl The URI to which the user will be redirected once authentication completes
 	 * @param clientUri The route of the client
 	 * @param state An optional arbitrary string that is returned as a URL param in your redirect URI
 	 * @return The URL for hosted authentication
@@ -28,8 +43,8 @@ public class Routes {
 			Scope[] scopes,
 			String emailAddress,
 			String successUrl,
-			@Nullable String clientUri,
-			@Nullable String state
+			String clientUri,
+			String state
 	) {
 		clientUri = clientUri != null ? clientUri : "";
 		HostedAuthentication.UrlBuilder authUrl = application

--- a/src/main/java/com/nylas/services/Routes.java
+++ b/src/main/java/com/nylas/services/Routes.java
@@ -5,6 +5,9 @@ import com.sun.istack.internal.Nullable;
 
 import java.io.IOException;
 
+/**
+ * Collection of helpful routes to be implemented into a backend application.
+ */
 public class Routes {
 	private final NylasApplication application;
 
@@ -12,6 +15,15 @@ public class Routes {
 		this.application = application;
 	}
 
+	/**
+	 * Build the URL for authenticating users to your application via Hosted Authentication
+	 * @param scopes Authentication scopes to request from the authenticating user
+	 * @param emailAddress The user's email address
+	 * @param successUrl The URI to which the user will be redirected once authentication completes
+	 * @param clientUri The route of the client
+	 * @param state An optional arbitrary string that is returned as a URL param in your redirect URI
+	 * @return The URL for hosted authentication
+	 */
 	public String buildAuthUrl(
 			Scope[] scopes,
 			String emailAddress,
@@ -34,14 +46,28 @@ public class Routes {
 		return authUrl.buildUrl();
 	}
 
+	/**
+	 * Exchange an authorization code for an access token
+	 * @param code One-time authorization code from Nylas
+	 * @return The object containing the access token and other information
+	 */
 	public AccessToken exchangeCodeForToken(String code) throws RequestFailedException, IOException {
 		return application.nativeAuthentication().fetchToken(code);
 	}
 
+	/**
+	 * Verify incoming webhook signature came from Nylas
+	 * @param nylasSignature The signature to verify
+	 * @param rawBody The raw body from the payload
+	 * @return True if the webhook signature was verified from Nylas
+	 */
 	public boolean verifyWebhookSignature(String nylasSignature, String rawBody) {
 		return Notification.isSignatureValid(rawBody, application.getClientSecret(), nylasSignature);
 	}
 
+	/**
+	 * The default paths the Nylas backend middlewares and frontend SDKs are preconfigured to.
+	 */
 	public enum DefaultRoutes {
 		BUILD_AUTH_URL("/nylas/generate-auth-url"),
 		EXCHANGE_CODE_FOR_TOKEN("/nylas/exchange-mailbox-token"),

--- a/src/main/java/com/nylas/services/Routes.java
+++ b/src/main/java/com/nylas/services/Routes.java
@@ -1,0 +1,62 @@
+package com.nylas.services;
+
+import com.nylas.*;
+import com.sun.istack.internal.Nullable;
+
+import java.io.IOException;
+
+public class Routes {
+	private final NylasApplication application;
+
+	public Routes(NylasApplication application) {
+		this.application = application;
+	}
+
+	public String buildAuthUrl(
+			Scope[] scopes,
+			String emailAddress,
+			String successUrl,
+			@Nullable String clientUri,
+			@Nullable String state
+	) {
+		clientUri = clientUri != null ? clientUri : "";
+		HostedAuthentication.UrlBuilder authUrl = application
+				.hostedAuthentication()
+				.urlBuilder()
+				.scopes(scopes)
+				.loginHint(emailAddress)
+				.redirectUri(clientUri + successUrl);
+
+		if(state != null) {
+			authUrl = authUrl.state(state);
+		}
+
+		return authUrl.buildUrl();
+	}
+
+	public AccessToken exchangeCodeForToken(String code) throws RequestFailedException, IOException {
+		return application.nativeAuthentication().fetchToken(code);
+	}
+
+	public boolean verifyWebhookSignature(String nylasSignature, String rawBody) {
+		return Notification.isSignatureValid(rawBody, application.getClientSecret(), nylasSignature);
+	}
+
+	public enum DefaultRoutes {
+		BUILD_AUTH_URL("/nylas/generate-auth-url"),
+		EXCHANGE_CODE_FOR_TOKEN("/nylas/exchange-mailbox-token"),
+		WEBHOOKS("/nylas/webhook"),
+
+		;
+
+		private final String path;
+
+		DefaultRoutes(String path) {
+			this.path = path;
+		}
+
+		public String getPath() {
+			return path;
+		}
+	}
+}

--- a/src/main/java/com/nylas/services/Routes.java
+++ b/src/main/java/com/nylas/services/Routes.java
@@ -68,21 +68,9 @@ public class Routes {
 	/**
 	 * The default paths the Nylas backend middlewares and frontend SDKs are preconfigured to.
 	 */
-	public enum DefaultRoutes {
-		BUILD_AUTH_URL("/nylas/generate-auth-url"),
-		EXCHANGE_CODE_FOR_TOKEN("/nylas/exchange-mailbox-token"),
-		WEBHOOKS("/nylas/webhook"),
-
-		;
-
-		private final String path;
-
-		DefaultRoutes(String path) {
-			this.path = path;
-		}
-
-		public String getPath() {
-			return path;
-		}
+	public static class Constants {
+		public static final String BUILD_AUTH_URL = "/nylas/generate-auth-url";
+		public static final String EXCHANGE_CODE_FOR_TOKEN = "/nylas/exchange-mailbox-token";
+		public static final String WEBHOOKS = "/nylas/webhook";
 	}
 }


### PR DESCRIPTION
# Description
This PR lays the foundation for the Java SDK to build middleware to integrate into your backend application with routes to some endpoints that would help with integrating authentication and webhook event. Currently provided routes:
*  `/nylas/generate-auth-url` - Endpoint that takes an optional email address and success redirect path, returns a URL used for authentication
*  `/nylas/exchange-mailbox-token` - Endpoint that takes a token from the JSON and exchanges that code for token, then calls a user-defined callback
* `/nylas/webhooks` - Verifies incoming webhook authenticity, parses it as an object, then can pass it to a callback function

This PR also includes additional integration with a Java Filter that has these routes built in, making it plug and play with many popular backend frameworks such as Spring.

This PR also includes support for local webhook development. The SDK will create a tunnel connection to a websocket server and registers it as a webhook callback to your Nylas account.

# Usage
## Routes

Here's an example application that uses the provided routes to handle a token exchange event:

```java
NylasClient nylas = new NylasClient();
NylasApplication nylasApplication = client.application("CLIENT_ID", "CLIENT_SECRET");
Routes routes = new Routes(nylasApplication);
// then you would perform matching like
if(request.getMethod().equals("POST")) {
  if(requestURI.equals(this.buildAuthUrl)) {
    Map<String, Object> json = parseRequestBody(request);
    String emailAddress = (String) json.get("email_address");
    String successUrl = (String) json.get("success_url");
    String authUrl = this.routes.buildAuthUrl(defaultScopes, emailAddress, successUrl, this.clientUri, null);
    response.getWriter().write(authUrl);
    response.setStatus(200);
  } else if(requestURI.equals(this.exchangeCodeForTokenUrl)) {
    Map<String, Object> json = parseRequestBody(request);
    String token = (String) json.get("token");
    AccessToken accessToken = this.routes.exchangeCodeForToken(token);
  } else if(requestURI.equals(this.webhooksUrl)) {
    String nylasSignatureHeader = request.getHeader(Notification.NYLAS_SIGNATURE_HEADER);
    if(nylasSignatureHeader != null && this.routes.verifyWebhookSignature(nylasSignatureHeader, jsonString)) {
      if(webhookNotificationCallback != null) {
        Notification parsedNotification = Notification.parseNotification(jsonString);
        webhookNotificationCallback.onNotification(request, response, parsedNotification);
      }
     }
  } else {
    continue;
   }
}
```

Here's an example application that implements a filter in Spring:

### MvcConfig.java
```java
@Configuration
@EnableWebMvc
@ComponentScan({ "com.baeldung.web.controller.status", "com.baeldung.requestmapping" })
public class MvcConfig implements WebMvcConfigurer {

    public static final Scope[] DEFAULT_SCOPES = {Scope.EMAIL_READ_ONLY};
    public static final String CLIENT_URI = "http://localhost:3000";

    public MvcConfig() {
        super();
    }

    @Bean
    public FilterRegistrationBean nylasFilterRegistration() {
        FilterRegistrationBean registration = new FilterRegistrationBean();
        registration.setFilter(nylasFilter());
        registration.setName("nylasFilter");
        registration.setOrder(1);
        return registration;
    }

    @Bean
    public NylasFilter nylasFilter() {
        NylasFilter nylasFilter = new NylasFilter(
                configureNylasApplication(),
                DEFAULT_SCOPES,
                new NylasMailboxTokenCallback()
        );
        nylasFilter.setClientUri(NylasConfiguration.CLIENT_URI);
        return nylasFilter;
    }

   public NylasApplication configureNylasApplication() {
        NylasClient client = new NylasClient();
        return client.application(clientId, clientSecret);
   }
}
```

### NylasMailboxTokenCallback.java
```java
public class NylasMailboxTokenCallback implements ExchangeMailboxTokenCallback {
  @Override
  public void onTokenExchange(HttpServletRequest request, HttpServletResponse response, AccessToken accessToken) {
    System.out.println("Access token was generated for " + accessToken.getEmailAddress());

    //TODO::Store the access token

    ObjectMapper mapper = new ObjectMapper();
    Map<String, String> responseBody = new HashMap<>();
    responseBody.put("id", UUID.randomUUID().toString());
    responseBody.put("emailAddress", accessToken.getEmailAddress());

    try {
      response.getWriter().write(mapper.writeValueAsString(responseBody));
      response.setContentType("application/json");
    } catch (IOException e) {
      e.printStackTrace();
    }

    response.setStatus(200);
  }

  @Override
  public void onTokenExchangeError(HttpServletRequest request, HttpServletResponse response, Exception e) {
    try {
      response.getWriter().write(e.getMessage());
    } catch (IOException ex) {
      ex.printStackTrace();
    }

    response.setStatus(500);
  }
}
```

## Webhooks
Getting started with webhooks for local testing is really easy:
```java
public class NylasWebhook {
  public static void main(String[] args) throws Exception {
    ExampleConf conf = new ExampleConf();
    NylasClient client = new NylasClient();
    NylasApplication application = client.application("65o8kqtg1eaghwe3ltywxg41h", "bkeqjfxdcmn486g7hifyqdbk4");

    WebhookTunnel webhookTunnel = new WebhookTunnel.Builder(application, new HandleNotifications()).build();
    webhookTunnel.connect();
  }
}

class HandleNotifications implements WebhookTunnel.WebhookHandler {
  private static final Logger log = LogManager.getLogger(HandleNotifications.class);

  @Override
  public void onOpen(short httpStatusCode) {
    log.info("OnOpen");
  }

  @Override
  public void onClose(int code, String reason, boolean remote) {
    log.info("onClose");
  }

  @Override
  public void onMessage(Notification notification) {
    log.info("onMessage");
  }

  @Override
  public void onError(Exception ex) {
    log.info("onError");
  }
}
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.