### PR TITLE
v1.19.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## [1.19.1] - Released 2023-01-18
 
 ### Changed
@@ -333,7 +349,8 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.19.0...HEAD
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.19.1...HEAD
+[1.19.1]: https://github.com/nylas/nylas-java/releases/tag/v1.19.1
 [1.19.0]: https://github.com/nylas/nylas-java/releases/tag/v1.19.0
 [1.18.0]: https://github.com/nylas/nylas-java/releases/tag/v1.18.0
 [1.17.0]: https://github.com/nylas/nylas-java/releases/tag/v1.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,14 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
-
-### Added
+## [1.19.1] - Released 2023-01-18
 
 ### Changed
 
 * Added missing setters for `FreeBusy`
 
-### Deprecated
-
 ### Fixed
 
 * Fixed typo in `Event.hide_participants`
-
-### Removed
-
-### Security
 
 ## [1.19.0] - Released 2022-11-18
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.19.0")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.19.1")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.19.0</version>
+      <version>1.19.1</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.20.0-SNAPSHOT
+version=1.19.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.19.1
+version=1.20.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New Nylas Java SDK v1.19.1 release brings the following changes:
- Added missing setters for `FreeBusy` (#140)
- Fixed typo in `Event.hide_participants` (#140)

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.