### PR TITLE
Tunnel fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This section contains changes that have been committed but not yet released.
 ### Fixed
 
 * Fix `Tunnel.onMessage` not emitting individual deltas
+* Change `java-websocket` dependency to `api` configuration
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Fixed
 
+* Fix `Tunnel.onMessage` not emitting individual deltas
+
 ### Removed
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Changed
 
+* Provide default implementations for `WebhookHandler` methods `onOpen`, `onClose`, and `onError`
+
 ### Deprecated
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation('org.slf4j:slf4j-api:1.7.30')
 
     // Websocket dependency
-    implementation('org.java-websocket:Java-WebSocket:1.5.3')
+    api('org.java-websocket:Java-WebSocket:1.5.3')
 
     ///////////////////////////////////
     // Test dependencies

--- a/src/main/java/com/nylas/services/Tunnel.java
+++ b/src/main/java/com/nylas/services/Tunnel.java
@@ -58,7 +58,6 @@ public class Tunnel extends WebSocketClient {
 	 */
 	@Override
 	public void onOpen(ServerHandshake handshakedata) {
-		log.trace("Opening websocket connection");
 		webhookHandler.onOpen(handshakedata.getHttpStatus());
 	}
 
@@ -87,7 +86,6 @@ public class Tunnel extends WebSocketClient {
 	 */
 	@Override
 	public void onClose(int code, String reason, boolean remote) {
-		log.trace("Closing websocket connection");
 		webhookHandler.onClose(code, reason, remote);
 	}
 
@@ -97,7 +95,6 @@ public class Tunnel extends WebSocketClient {
 	 */
 	@Override
 	public void onError(Exception ex) {
-		log.trace("Error encountered during websocket connection");
 		webhookHandler.onError(ex);
 	}
 
@@ -184,9 +181,18 @@ public class Tunnel extends WebSocketClient {
 	 * An interface for implementing classes to handle events from the {@link Tunnel}
 	 */
 	public interface WebhookHandler {
-		void onOpen(short httpStatusCode);
-		void onClose(int code, String reason, boolean remote);
 		void onMessage(Notification notification);
-		void onError(Exception ex);
+
+		default void onOpen(short httpStatusCode) {
+			log.trace("Opening websocket connection. Code: {}", httpStatusCode);
+		}
+
+		default void onClose(int code, String reason, boolean remote) {
+			log.trace("Closing websocket connection. Code: {}, Reason: {}, Remote: {}", code, reason, remote);
+		}
+
+		default void onError(Exception ex) {
+			log.error("Error encountered during websocket connection. Exception: {}", ex.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/nylas/services/Tunnel.java
+++ b/src/main/java/com/nylas/services/Tunnel.java
@@ -63,7 +63,7 @@ public class Tunnel extends WebSocketClient {
 
 	/**
 	 * {@inheritDoc}
-	 * Calls {@link WebhookHandler#onMessage(Notification)}
+	 * Calls {@link WebhookHandler#onMessage(Notification.Delta)}
 	 */
 	@Override
 	public void onMessage(String message) {
@@ -77,7 +77,9 @@ public class Tunnel extends WebSocketClient {
 
 		// Parse notification from JSON body and call onMessage callback
 		Notification notification = Notification.parseNotification(jsonBody);
-		webhookHandler.onMessage(notification);
+		for(Notification.Delta delta : notification.getDeltas()) {
+			webhookHandler.onMessage(delta);
+		}
 	}
 
 	/**
@@ -181,7 +183,7 @@ public class Tunnel extends WebSocketClient {
 	 * An interface for implementing classes to handle events from the {@link Tunnel}
 	 */
 	public interface WebhookHandler {
-		void onMessage(Notification notification);
+		void onMessage(Notification.Delta delta);
 
 		default void onOpen(short httpStatusCode) {
 			log.trace("Opening websocket connection. Code: {}", httpStatusCode);


### PR DESCRIPTION
# Description
This PR contains multiple small fixes for the Websocket implementation provided in #145:
* Provide default implementations for `WebhookHandler` methods `onOpen`, `onClose`, and `onError`
* Fix `Tunnel.onMessage` not emitting individual deltas
* Change `java-websocket` dependency to `api` configuration

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.