### PR TITLE
Add scheduler support for the EU region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This section contains changes that have been committed but not yet released.
 ### Added
 
 * Added missing `content_disposition` field in `File`
+* Added scheduler support for the EU region
 
 ### Changed
 

--- a/src/main/java/com/nylas/NylasClient.java
+++ b/src/main/java/com/nylas/NylasClient.java
@@ -24,8 +24,9 @@ import okhttp3.ResponseBody;
  */
 public class NylasClient {
 
-	public static final String DEFAULT_BASE_URL = "https://api.nylas.com";
-	
+	public static final String DEFAULT_BASE_URL = "https://api.nylas.com/";
+	public static final String EU_BASE_URL = "https://ireland.api.nylas.com/";
+
 	private final HttpUrl baseUrl;
 	private final OkHttpClient httpClient;
 

--- a/src/main/java/com/nylas/Schedulers.java
+++ b/src/main/java/com/nylas/Schedulers.java
@@ -13,7 +13,8 @@ import java.util.Map;
 
 public class Schedulers extends RestfulDAO<Scheduler> {
 
-	private final String SCHEDULER_API_BASE_URL = "https://api.schedule.nylas.com";
+	private static final String SCHEDULER_API_BASE_URL = "https://api.schedule.nylas.com/";
+	private static final String SCHEDULER_API_EU_BASE_URL = "https://ireland.api.schedule.nylas.com/";
 
 	Schedulers(NylasClient client, String accessToken) {
 		super(client, Scheduler.class, "manage/pages", accessToken);

--- a/src/main/java/com/nylas/Schedulers.java
+++ b/src/main/java/com/nylas/Schedulers.java
@@ -1,6 +1,5 @@
 package com.nylas;
 
-import com.nylas.*;
 import com.nylas.scheduler.*;
 import okhttp3.HttpUrl;
 
@@ -15,13 +14,25 @@ public class Schedulers extends RestfulDAO<Scheduler> {
 
 	private static final String SCHEDULER_API_BASE_URL = "https://api.schedule.nylas.com/";
 	private static final String SCHEDULER_API_EU_BASE_URL = "https://ireland.api.schedule.nylas.com/";
+	private final String baseUrl;
 
 	Schedulers(NylasClient client, String accessToken) {
 		super(client, Scheduler.class, "manage/pages", accessToken);
+
+		// Set the Scheduler URL based on the URL set in the client
+		switch (client.newUrlBuilder().toString()) {
+			case NylasClient.EU_BASE_URL:
+				baseUrl = SCHEDULER_API_EU_BASE_URL;
+				break;
+			case NylasClient.DEFAULT_BASE_URL:
+			default:
+				baseUrl = SCHEDULER_API_BASE_URL;
+				break;
+		}
 	}
 
 	protected HttpUrl.Builder getCollectionUrl() {
-		return HttpUrl.get(SCHEDULER_API_BASE_URL).newBuilder().addPathSegments(collectionPath);
+		return HttpUrl.get(baseUrl).newBuilder().addPathSegments(collectionPath);
 	}
 
 	public RemoteCollection<Scheduler> list() throws IOException, RequestFailedException {
@@ -148,6 +159,6 @@ public class Schedulers extends RestfulDAO<Scheduler> {
 	}
 
 	private HttpUrl.Builder schedulerUrl() {
-		return HttpUrl.get(SCHEDULER_API_BASE_URL).newBuilder().addPathSegment("schedule");
+		return HttpUrl.get(baseUrl).newBuilder().addPathSegment("schedule");
 	}
 }

--- a/src/test/java/com/nylas/NylasAccountTest.java
+++ b/src/test/java/com/nylas/NylasAccountTest.java
@@ -17,6 +17,7 @@ public class NylasAccountTest {
     @BeforeEach
     private void init() {
         nylasClient = mock(NylasClient.class);
+        when(nylasClient.newUrlBuilder()).thenReturn(HttpUrl.get(NylasClient.DEFAULT_BASE_URL).newBuilder());
     }
 
     @Test


### PR DESCRIPTION
# Description
This PR enables support for scheduler using the EU region. Depending on the regional URL set for the Nylas SDK, the region for the scheduler will get set as well.

# Usage
```java
public class NylasExample {
  public static void main(String[] args) throws Exception {
    // Setup Nylas client, defaulting to US region
    NylasClient client = new NylasClient();
    NylasApplication application = client.account("ACESS_TOKEN");
    Schedulers usScheduler = application.schedulers(); // Scheduler URL pointing to https://api.schedule.nylas.com/

    // Setup Nylas client for the EU region
    NylasClient euClient = new NylasClient.Builder()
        .baseUrl(NylasClient.EU_BASE_URL)
        .build();
    NylasApplication euApplication = euClient.account("ACESS_TOKEN");
    Schedulers euScheduler = euApplication.schedulers(); // Scheduler URL pointing to https://ireland.api.schedule.nylas.com/
  }
}
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.