### PR TITLE
v1.21.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,16 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
-
-This section contains changes that have been committed but not yet released.
+## [1.21.0] - Released 2023-02-14
 
 ### Added
 
 * Added missing `content_disposition` field in `File`
+* Added toJSON() and toMap() support to account owned models
 * Added scheduler support for the EU region
-
-### Changed
-
-### Deprecated
 
 ### Fixed
 
 * Fixed NullPointerException sporadically occurring when calling `Message.toString()`
-
-### Removed
-
-### Security
 
 ## [1.20.1] - Released 2023-02-09
 
@@ -380,7 +371,8 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.20.1...HEAD
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.21.0...HEAD
+[1.21.0]: https://github.com/nylas/nylas-java/releases/tag/v1.21.0
 [1.20.1]: https://github.com/nylas/nylas-java/releases/tag/v1.20.1
 [1.20.0]: https://github.com/nylas/nylas-java/releases/tag/v1.20.0
 [1.19.2]: https://github.com/nylas/nylas-java/releases/tag/v1.19.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+This section contains changes that have been committed but not yet released.
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## [1.21.0] - Released 2023-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ If you have a question about the Nylas Communications Platform, please reach out
 
 **Setup via Gradle**: If you're using Gradle, add the following to your dependencies section of build.gradle:
 
-    implementation("com.nylas.sdk:nylas-java-sdk:1.20.1")
+    implementation("com.nylas.sdk:nylas-java-sdk:1.21.0")
 
 **Setup via Maven**: For projects using Maven, add the following to your POM file:
 
     <dependency>
       <groupId>com.nylas.sdk</groupId>
       <artifactId>nylas-java-sdk</artifactId>
-      <version>1.20.1</version>
+      <version>1.21.0</version>
     </dependency>
     
 **Build from source**: To build from source, clone this repo and build the project with Gradle.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.21.0
+version=1.22.0-SNAPSHOT
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=1.21.0-SNAPSHOT
+version=1.21.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Description
New Nylas Java SDK release contains the following additions:
### Added

* Added missing `content_disposition` field in `File` (#149)
* Added toJSON() and toMap() support to account owned models (#150)
* Added scheduler support for the EU region (#151)

### Fixed

* Fixed NullPointerException sporadically occurring when calling `Message.toString()` (#149)

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.