### PR TITLE
Create a webhook should return secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Nylas maintains a [reference guide for the Kotlin and Java SDK](https://nylas-ja
 
 ## ✨ Upgrading from 1.x
 
-See [UPGRADING.md](UPGRADING.md) for instructions on upgrading from 1.x to 2.x.
+See [UPGRADE.md](UPGRADING.md) for instructions on upgrading from 1.x to 2.x.
 
 **Note**: The Kotlin/Java SDK 2.x is not compatible with the Nylas API earlier than v3-beta.
 

--- a/src/main/kotlin/com/nylas/models/WebhookWithSecret.kt
+++ b/src/main/kotlin/com/nylas/models/WebhookWithSecret.kt
@@ -3,7 +3,7 @@ package com.nylas.models
 import com.squareup.moshi.Json
 
 /**
- * Class representing a Nylas webhook with secret. Used when rotating a webhook secret.
+ * Class representing a Nylas webhook with secret.
  */
 data class WebhookWithSecret(
   /**

--- a/src/main/kotlin/com/nylas/resources/Webhooks.kt
+++ b/src/main/kotlin/com/nylas/resources/Webhooks.kt
@@ -40,11 +40,12 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
    * @return The created webhook destination
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(requestBody: CreateWebhookRequest): Response<Webhook> {
+  fun create(requestBody: CreateWebhookRequest): Response<WebhookWithSecret> {
     val path = "v3/webhooks"
     val adapter = JsonHelper.moshi().adapter(CreateWebhookRequest::class.java)
+    val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody)
   }
 
   /**


### PR DESCRIPTION
# Description
Creating a webhook should return a `WebhookWithSecret` response.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.