### PR TITLE
(Kotlin) Rotate secret should be post

### DIFF
--- a/src/main/kotlin/com/nylas/resources/Webhooks.kt
+++ b/src/main/kotlin/com/nylas/resources/Webhooks.kt
@@ -80,7 +80,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
   fun rotateSecret(webhookId: String): Response<WebhookWithSecret> {
     val path = String.format("v3/webhooks/%s/rotate-secret", webhookId)
     val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
-    return client.executePut(path, responseType)
+    return client.executePost(path, responseType)
   }
 
   /**


### PR DESCRIPTION
# License

(Kotlin) Right now rotateSecret is set as PUT method, although it should POST according to the documentation. This error gets generated when calling the method.

```
Exception in thread "main" java.lang.IllegalArgumentException: method PUT must have a request body.
```

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.