### PR TITLE
Fixed optional field for `GetAvailabilityResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 * Return webhook object with secret when creating a webhook
 * Fixed HTTP method for rotating webhook secret
+* Fixed optional field for `GetAvailabilityResponse`
 
 ## [2.0.0-beta.1] - Released 2023-08-16
 

--- a/src/main/kotlin/com/nylas/models/GetAvailabilityResponse.kt
+++ b/src/main/kotlin/com/nylas/models/GetAvailabilityResponse.kt
@@ -7,14 +7,14 @@ import com.squareup.moshi.Json
  */
 data class GetAvailabilityResponse(
   /**
-   * This property is only populated for round-robin events.
-   * It will contain the order in which the accounts would be next in line to attend the proposed meeting.
-   */
-  @Json(name = "order")
-  val order: List<String>,
-  /**
    * The available time slots where a new meeting can be created for the requested preferences.
    */
   @Json(name = "time_slots")
   val timeSlots: List<TimeSlot>,
+  /**
+   * This property is only populated for round-robin events.
+   * It will contain the order in which the accounts would be next in line to attend the proposed meeting.
+   */
+  @Json(name = "order")
+  val order: List<String>? = null,
 )

--- a/src/main/kotlin/com/nylas/models/GetAvailabilityResponse.kt
+++ b/src/main/kotlin/com/nylas/models/GetAvailabilityResponse.kt
@@ -7,14 +7,14 @@ import com.squareup.moshi.Json
  */
 data class GetAvailabilityResponse(
   /**
-   * The available time slots where a new meeting can be created for the requested preferences.
-   */
-  @Json(name = "time_slots")
-  val timeSlots: List<TimeSlot>,
-  /**
    * This property is only populated for round-robin events.
    * It will contain the order in which the accounts would be next in line to attend the proposed meeting.
    */
   @Json(name = "order")
   val order: List<String>? = null,
+  /**
+   * The available time slots where a new meeting can be created for the requested preferences.
+   */
+  @Json(name = "time_slots")
+  val timeSlots: List<TimeSlot>? = null,
 )

--- a/src/main/kotlin/com/nylas/resources/Calendars.kt
+++ b/src/main/kotlin/com/nylas/resources/Calendars.kt
@@ -94,7 +94,9 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
       .adapter(GetAvailabilityRequest::class.java)
       .toJson(request)
 
-    return client.executePost(path, GetAvailabilityResponse::class.java, serializedRequestBody)
+    val responseType = Types.newParameterizedType(Response::class.java, GetAvailabilityResponse::class.java)
+
+    return client.executePost(path, responseType, serializedRequestBody)
   }
 
   /**


### PR DESCRIPTION
# Description
In the response object for getting availability, `order` is only populated for round-robin events.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.