### PR TITLE
Make provider optional java/kotlin

### DIFF
--- a/src/main/kotlin/com/nylas/models/Conferencing.kt
+++ b/src/main/kotlin/com/nylas/models/Conferencing.kt
@@ -14,7 +14,7 @@ sealed class Conferencing {
      * The conferencing provider
      */
     @Json(name = "provider")
-    val provider: ConferencingProvider,
+    val provider: ConferencingProvider? = null,
     /**
      * Empty dict to indicate an intention to autocreate a video link.
      * Additional provider settings may be included in autocreate.settings, but Nylas does not validate these.
@@ -31,7 +31,7 @@ sealed class Conferencing {
      * The conferencing provider
      */
     @Json(name = "provider")
-    val provider: ConferencingProvider,
+    val provider: ConferencingProvider? = null,
     /**
      * The conferencing details
      */
@@ -39,7 +39,7 @@ sealed class Conferencing {
     val details: Config,
   ) : Conferencing() {
     /**
-     * Class representation of a the configuration for a conferencing object
+     * Class representation of the configuration for a conferencing object
      */
     data class Config(
       /**


### PR DESCRIPTION
# License

The Provider was causing problems so I make it optional

https://nylas.atlassian.net/browse/TW-2426

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.