### PR TITLE
Add getter for GetFreeBusyResponse object type

### DIFF
--- a/src/main/kotlin/com/nylas/models/GetFreeBusyResponse.kt
+++ b/src/main/kotlin/com/nylas/models/GetFreeBusyResponse.kt
@@ -52,6 +52,12 @@ sealed class GetFreeBusyResponse {
     override val email: String,
   ) : GetFreeBusyResponse()
 
+  /**
+   * Returns the type of object.
+   * @return The type of object.
+   */
+  fun getObject() = obj
+
   companion object {
     /**
      * A JsonAdapter factory for the [GetFreeBusyResponse] sealed class (used for deserialization).

--- a/src/main/kotlin/com/nylas/resources/Calendars.kt
+++ b/src/main/kotlin/com/nylas/resources/Calendars.kt
@@ -106,7 +106,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
    * @return The free/busy response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun getFreeBusy(identifier: String, request: GetFreeBusyRequest): Response<GetFreeBusyResponse> {
+  fun getFreeBusy(identifier: String, request: GetFreeBusyRequest): Response<List<GetFreeBusyResponse>> {
     val path = String.format("v3/grants/%s/calendars/free-busy", identifier)
 
     val serializedRequestBody = JsonHelper.moshi()


### PR DESCRIPTION
# Description
Adds a getter for getting the object type of a free busy response (free busy vs. error).

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.