### PR TITLE
v2.0.0 beta 2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # Nylas Java SDK Changelog
 
-## [2.0.0-beta.2] - TBD
+## [2.0.0-beta.2] - Released 2023-11-21
 
 ### Added
 * Added support for the free-busy endpoint
-* Added Messages, Drafts, and Smart Compose APIs support
+* Added support for Messages, Drafts, and Smart Compose APIs
 * Added support for custom authentication, connectors, and credentials APIs
+* Added support for folders API
 * Added support for attachments API
+* Added getter for `GetFreeBusyResponse` `object` field
 
 ### Changed
 * Return webhook object with secret when creating a webhook
 * Fixed HTTP method for rotating webhook secret
+* Fixed Redirect URI endpoint path
+* Fixed query parameter serialization
 * Fixed optional field for `GetAvailabilityResponse`
+* Fixed optional field for `Conferencing`
 
 ## [2.0.0-beta.1] - Released 2023-08-16
 
@@ -408,7 +413,9 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v1.21.0...HEAD
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v2.0.0-beta.2...HEAD
+[2.0.0-beta.2]: https://github.com/nylas/nylas-java/releases/tag/v2.0.0-beta.2
+[2.0.0-beta.1]: https://github.com/nylas/nylas-java/releases/tag/v2.0.0-beta.1
 [1.21.0]: https://github.com/nylas/nylas-java/releases/tag/v1.21.0
 [1.20.1]: https://github.com/nylas/nylas-java/releases/tag/v1.20.1
 [1.20.0]: https://github.com/nylas/nylas-java/releases/tag/v1.20.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.0.0-beta.1
+version=2.0.0-beta.2
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Changelog

### Added
* Added support for the free-busy endpoint (#163)
* Added support for Messages, Drafts, and Smart Compose APIs (#166)
* Added support for custom authentication, connectors, and credentials APIs (#165)
* Added support for folders API (#168)
* Added support for attachments API (#171)
* Added getter for `GetFreeBusyResponse` `object` field (#172)

### Changed
* Return webhook object with secret when creating a webhook (#162)
* Fixed HTTP method for rotating webhook secret (#164)
* Fixed Redirect URI endpoint path (#167)
* Fixed query parameter serialization (#167)
* Fixed optional field for `GetAvailabilityResponse` (#169)
* Fixed optional field for `Conferencing` (#170)

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.