### PR TITLE
Fixed int type being serialized to double sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Nylas Java SDK Changelog
 
+## [2.0.0-beta.3] - TBD
+* Fixed int type being serialized to double sometimes
+
 ## [2.0.0-beta.2] - Released 2023-11-21
 
 ### Added

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -415,6 +415,9 @@ class NylasClient(
             url.addQueryParameter(key, "$k:$v")
           }
         }
+        is Double -> {
+          url.addQueryParameter(key, value.toInt().toString())
+        }
         else -> {
           url.addQueryParameter(key, value.toString())
         }


### PR DESCRIPTION
# Description
Sometimes when serializing query parameters, it converts an integer to a double. The decimal produced breaks the API call. We ensure that we are handling the Double instance specifically.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.