### PR TITLE
Fix Exchanging Token always returns 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Nylas Java SDK Changelog
 
+## [2.0.0-beta.3] - TBD
+* Fixed `Auth.exchangeCodeForToken` always returning 401
+
 ## [2.0.0-beta.2] - Released 2023-11-21
 
 ### Added

--- a/src/main/kotlin/com/nylas/interceptors/ContentHeadersInterceptor.kt
+++ b/src/main/kotlin/com/nylas/interceptors/ContentHeadersInterceptor.kt
@@ -15,15 +15,21 @@ class ContentHeadersInterceptor : Interceptor {
     val path = request.url().encodedPath()
     val contentHeader = request.header(NylasClient.HttpHeaders.CONTENT_TYPE.headerName)
     if (contentHeader == null && !isDownloadablePath(path)) {
-      val enhancedRequest = request
-        .newBuilder()
-        .header(
+      val enhancedRequest = request.newBuilder()
+      if (request.body() != null && request.body()!!.contentType() != null) {
+        enhancedRequest.header(
+          NylasClient.HttpHeaders.CONTENT_TYPE.headerName,
+          request.body()!!.contentType()!!.toString(),
+        )
+      } else if (request.body() != null) {
+        enhancedRequest.header(
           NylasClient.HttpHeaders.CONTENT_TYPE.headerName,
           NylasClient.MediaType.APPLICATION_JSON.mediaType,
         )
-        .header(NylasClient.HttpHeaders.ACCEPT.headerName, NylasClient.MediaType.APPLICATION_JSON.mediaType)
-        .build()
-      return chain.proceed(enhancedRequest)
+      }
+
+      enhancedRequest.header(NylasClient.HttpHeaders.ACCEPT.headerName, NylasClient.MediaType.APPLICATION_JSON.mediaType)
+      return chain.proceed(enhancedRequest.build())
     }
     return chain.proceed(request)
   }

--- a/src/main/kotlin/com/nylas/models/NylasOAuthError.kt
+++ b/src/main/kotlin/com/nylas/models/NylasOAuthError.kt
@@ -29,5 +29,10 @@ data class NylasOAuthError(
   /**
    * The HTTP status code of the error response.
    */
+  @Json(name = "request_id")
+  override var requestId: String? = null,
+  /**
+   * The HTTP status code of the error response.
+   */
   override var statusCode: Int? = null,
-) : AbstractNylasApiError(error, statusCode)
+) : AbstractNylasApiError(error, statusCode, requestId)

--- a/src/main/kotlin/com/nylas/util/JsonHelper.kt
+++ b/src/main/kotlin/com/nylas/util/JsonHelper.kt
@@ -193,7 +193,7 @@ class JsonHelper {
       return json
     }
 
-    private val jsonType = MediaType.parse("application/json; charset=utf-8")
+    private val jsonType = MediaType.parse("application/json")
 
     /**
      * Get the JSON media type.
@@ -225,7 +225,7 @@ class JsonHelper {
      */
     @JvmStatic
     fun jsonRequestBody(json: String): RequestBody {
-      return RequestBody.create(jsonType(), json)
+      return RequestBody.create(jsonType(), json.toByteArray())
     }
   }
 }


### PR DESCRIPTION
# Description
The API doesn't like the trailing "charset=utf-8" in the content-type header. Removing it allows the calls to process properly for auth.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.