### PR TITLE
Fix error when sending message or updating draft

### DIFF
--- a/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
+++ b/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
@@ -1,5 +1,7 @@
 package com.nylas.models
 
+import com.squareup.moshi.Json
+
 /**
  * Class representing a request to send a message.
  */
@@ -7,66 +9,81 @@ data class SendMessageRequest(
   /**
    * An array of message recipients.
    */
+  @Json(name = "to")
   val to: List<EmailName>,
   /**
    * An array of bcc recipients.
    */
+  @Json(name = "bcc")
   val bcc: List<EmailName>? = null,
   /**
    * An array of cc recipients.
    */
+  @Json(name = "cc")
   val cc: List<EmailName>? = null,
   /**
    * An array of name and email pairs that override the sent reply-to headers.
    */
+  @Json(name = "reply_to")
   val replyTo: List<EmailName>? = null,
   /**
    * An array of files to attach to the message.
    */
+  @Transient
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
    * A short snippet of the message body.
    * This is the first 100 characters of the message body, with any HTML tags removed.
    */
+  @Json(name = "snippet")
   val snippet: String? = null,
   /**
    * The message subject.
    */
+  @Json(name = "subject")
   val subject: String? = null,
   /**
    * A reference to the parent thread object.
    * If this is a new draft, the thread will be empty.
    */
+  @Json(name = "thread_id")
   val threadId: String? = null,
   /**
    * The full HTML message body.
    * Messages with only plain-text representations are up-converted to HTML.
    */
+  @Json(name = "body")
   val body: String? = null,
   /**
    * Whether or not the message has been starred by the user.
    */
+  @Json(name = "starred")
   val starred: Boolean? = null,
   /**
    * Whether or not the message has been read by the user.
    */
+  @Json(name = "unread")
   val unread: Boolean? = null,
   /**
    * Unix timestamp to send the message at.
    */
+  @Json(name = "send_at")
   val sendAt: Int? = null,
   /**
    * The ID of the message that you are replying to.
    */
+  @Json(name = "reply_to_message_id")
   val replyToMessageId: String? = null,
   /**
    * Options for tracking opens, links, and thread replies.
    */
+  @Json(name = "tracking_options")
   val trackingOptions: TrackingOptions? = null,
   /**
    * Whether or not to use draft support.
    * This is primarily used when dealing with large attachments.
    */
+  @Json(name = "use_draft")
   val useDraft: Boolean? = null,
 ) : IMessageAttachmentRequest {
   /**
@@ -81,7 +98,7 @@ data class SendMessageRequest(
     private var replyTo: List<EmailName>? = null
     private var attachments: List<CreateAttachmentRequest>? = null
     private var snippet: String? = null
-    private var subject: String? = null
+    internal var subject: String? = null
     private var threadId: String? = null
     private var body: String? = null
     private var starred: Boolean? = null

--- a/src/main/kotlin/com/nylas/models/UpdateDraftRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateDraftRequest.kt
@@ -1,5 +1,7 @@
 package com.nylas.models
 
+import com.squareup.moshi.Json
+
 /**
  * Class representing a request to update a draft.
  */
@@ -7,51 +9,63 @@ data class UpdateDraftRequest(
   /**
    * An array of message recipients.
    */
+  @Json(name = "to")
   val to: List<EmailName>? = null,
   /**
    * An array of bcc recipients.
    */
+  @Json(name = "bcc")
   val bcc: List<EmailName>? = null,
   /**
    * An array of cc recipients.
    */
+  @Json(name = "cc")
   val cc: List<EmailName>? = null,
   /**
    * An array of name and email pairs that override the sent reply-to headers.
    */
+  @Json(name = "reply_to")
   val replyTo: List<EmailName>? = null,
   /**
    * An array of files to attach to the message.
    */
+  @Transient
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
    * The message subject.
    */
+  @Json(name = "subject")
   val subject: String? = null,
   /**
    * The full HTML message body.
    * Messages with only plain-text representations are up-converted to HTML.
    */
+  @Json(name = "body")
   val body: String? = null,
   /**
    * Whether or not the message has been starred by the user.
    */
+  @Json(name = "starred")
   val starred: Boolean? = null,
   /**
    * Whether or not the message has been read by the user.
    */
+  @Json(name = "unread")
   val unread: Boolean? = null,
   /**
    * Unix timestamp to send the message at.
    */
+  @Json(name = "send_at")
   val sendAt: Int? = null,
   /**
    * The ID of the message that you are replying to.
    */
+  @Json(name = "reply_to_message_id")
   val replyToMessageId: String? = null,
   /**
    * Options for tracking opens, links, and thread replies.
    */
+  @Json(name = "tracking_options")
   val trackingOptions: TrackingOptions? = null,
 ) : IMessageAttachmentRequest {
   /**

--- a/src/main/kotlin/com/nylas/resources/Drafts.kt
+++ b/src/main/kotlin/com/nylas/resources/Drafts.kt
@@ -68,8 +68,9 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
       .adapter(UpdateDraftRequest::class.java)
       .toJson(attachmentLessPayload)
     val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
+    val responseType = Types.newParameterizedType(Response::class.java, Draft::class.java)
 
-    return client.executeFormRequest(path, NylasClient.HttpMethod.PUT, multipart, Draft::class.java)
+    return client.executeFormRequest(path, NylasClient.HttpMethod.PUT, multipart, responseType)
   }
 
   /**

--- a/src/main/kotlin/com/nylas/resources/Messages.kt
+++ b/src/main/kotlin/com/nylas/resources/Messages.kt
@@ -82,8 +82,9 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
       .adapter(SendMessageRequest::class.java)
       .toJson(attachmentLessPayload)
     val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
+    val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
 
-    return client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, Message::class.java)
+    return client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType)
   }
 
   /**


### PR DESCRIPTION
# Description
There were a couple of errors with sending messages and updating drafts. First was `attachments` was attempting to be serialized when it should have been marked as Transient. Secondly, we were passing the wrong type to deserialize the response.

https://nylas.atlassian.net/browse/TW-2450

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.