### PR TITLE
Fix issue with sending scheduled messages & Add draft send support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Nylas Java SDK Changelog
 
+## [2.0.0-beta.4] - TBD
+
+### Added
+* Added support for sending drafts
+
+### Changed
+* Fixed issue with sending scheduled messages
+
 ## [2.0.0-beta.3] - Released 2023-12-18
 
 ### Added

--- a/src/main/kotlin/com/nylas/models/Message.kt
+++ b/src/main/kotlin/com/nylas/models/Message.kt
@@ -112,6 +112,18 @@ data class Message(
    */
   @Json(name = "metadata")
   val metadata: Map<String, Any>? = null,
+  /**
+   * The ID of the scheduled message.
+   * Only present if the message was scheduled to be sent.
+   */
+  @Json(name = "schedule_id")
+  val scheduleId: String? = null,
+  /**
+   * The time the message was scheduled to be sent, in epoch time.
+   * Only present if the message was scheduled to be sent.
+   */
+  @Json(name = "send_at")
+  val sendAt: Long? = null,
 ) : IMessage {
   /**
    * Get the type of object.

--- a/src/main/kotlin/com/nylas/models/Message.kt
+++ b/src/main/kotlin/com/nylas/models/Message.kt
@@ -7,11 +7,6 @@ import com.squareup.moshi.Json
  */
 data class Message(
   /**
-   * The unique identifier for the message.
-   */
-  @Json(name = "id")
-  val id: String,
-  /**
    * Grant ID of the Nylas account.
    */
   @Json(name = "grant_id")
@@ -22,16 +17,16 @@ data class Message(
   @Json(name = "from")
   val from: List<EmailName>,
   /**
-   * Unix timestamp of when the message was received by the mail server.
-   * This may be different from the unverified Date header in raw message object.
-   */
-  @Json(name = "date")
-  val date: Long,
-  /**
    * The type of object.
    */
   @Json(name = "object")
   private val obj: String = "message",
+  /**
+   * The unique identifier for the message.
+   * Note: The ID may not be present for scheduled messages until the message is sent.
+   */
+  @Json(name = "id")
+  val id: String? = null,
   /**
    * An array of bcc recipients.
    */
@@ -106,6 +101,12 @@ data class Message(
    */
   @Json(name = "created_at")
   val createdAt: Long? = null,
+  /**
+   * Unix timestamp of when the message was received by the mail server.
+   * This may be different from the unverified Date header in raw message object.
+   */
+  @Json(name = "date")
+  val date: Long? = null,
   /**
    * A list of key-value pairs storing additional data.
    */

--- a/src/main/kotlin/com/nylas/resources/Drafts.kt
+++ b/src/main/kotlin/com/nylas/resources/Drafts.kt
@@ -84,4 +84,17 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, draftId)
     return destroyResource(path)
   }
+
+  /**
+   * Send a Draft
+   * @param identifier The identifier of the grant to act upon
+   * @param draftId The id of the Draft to send.
+   * @return The sent Draft
+   */
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  fun send(identifier: String, draftId: String): Response<Message> {
+    val path = String.format("v3/grants/%s/drafts/%s", identifier, draftId)
+    val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
+    return client.executePost(path, responseType)
+  }
 }


### PR DESCRIPTION
# Description
This PR fixes an issue with handling the response of scheduled send. Also adds support for sending drafts.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.