### PR TITLE
Move `Grants` to `NylasClient` and custom authentication to `Auth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Nylas Java SDK Changelog
 
+## [2.0.0-beta.4] - TBD
+
+### BREAKING CHANGES
+* Moved grants API out of `Auth` to `NylasClient`
+* Moved `Grants.create()` to `Auth.customAuthentication()`
+
 ## [2.0.0-beta.3] - Released 2023-12-18
 
 ### Added

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -136,6 +136,14 @@ class NylasClient(
   }
 
   /**
+   * Access the Grants API
+   * @return The Grants API
+   */
+  fun grants(): Grants {
+    return Grants(this)
+  }
+
+  /**
    * Access the Messages API
    * @return The Messages API
    */

--- a/src/main/kotlin/com/nylas/resources/Auth.kt
+++ b/src/main/kotlin/com/nylas/resources/Auth.kt
@@ -95,6 +95,22 @@ class Auth(private val client: NylasClient) {
   }
 
   /**
+   * Create a grant via custom authentication
+   * @param requestBody The values to create the grant with
+   * @return The created grant
+   */
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  fun customAuthentication(requestBody: CreateGrantRequest): Response<Grant> {
+    val path = "v3/connect/custom"
+    val serializedRequestBody = JsonHelper.moshi()
+      .adapter(CreateGrantRequest::class.java)
+      .toJson(requestBody)
+    val responseType = Types.newParameterizedType(Response::class.java, Grant::class.java)
+
+    return client.executePost(path, responseType, serializedRequestBody)
+  }
+
+  /**
    * Refresh an access token
    * @param request The refresh token request
    * @return The response containing the new access token

--- a/src/main/kotlin/com/nylas/resources/Auth.kt
+++ b/src/main/kotlin/com/nylas/resources/Auth.kt
@@ -17,15 +17,6 @@ import java.util.*
  * @param client The configured Nylas API client
  */
 class Auth(private val client: NylasClient) {
-
-  /**
-   * Access the Grants API
-   * @return The Grants API
-   */
-  fun grants(): Grants {
-    return Grants(client)
-  }
-
   /**
    * Build the URL for authenticating users to your application with OAuth 2.0
    * @param config The configuration for building the URL

--- a/src/main/kotlin/com/nylas/resources/Grants.kt
+++ b/src/main/kotlin/com/nylas/resources/Grants.kt
@@ -36,21 +36,6 @@ class Grants(client: NylasClient) : Resource<Grant>(client, Grant::class.java) {
   }
 
   /**
-   * Create a Grant via Custom Authentication
-   * @param requestBody The values to create the Grant with
-   * @return The created Grant
-   */
-  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(requestBody: CreateGrantRequest): Response<Grant> {
-    val path = "v3/connect/custom"
-    val serializedRequestBody = JsonHelper.moshi()
-      .adapter(CreateGrantRequest::class.java)
-      .toJson(requestBody)
-
-    return createResource(path, serializedRequestBody)
-  }
-
-  /**
    * Update a Grant
    * @param grantId The id of the Grant to update.
    * @param requestBody The values to update the Grant with


### PR DESCRIPTION
# Description
⚠️ This is a breaking change ⚠️ 

This PR moves the following:
* `Auth.grants()` to `NylasClient.grants()`
* `Grants.create()` to `Auth.customAuthentication()`

Functionality remains the same.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.