### PR TITLE
Added support for overriding the Event ID when updating, for recurring events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This section contains changes that have been committed but not yet released.
 
 ### Added
 
+* Added support for overriding the Event ID when updating, for recurring events
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/nylas/Event.java
+++ b/src/main/java/com/nylas/Event.java
@@ -346,6 +346,10 @@ public class Event extends AccountOwnedModel implements JsonObject {
 				"The number of participants in the event exceeds the set capacity");
 	}
 
+	protected void setId(String id) {
+		this.id = id;
+	}
+
 	@Override
 	protected Map<String, Object> getWritableFields(boolean creation) {
 		if (!creation) {

--- a/src/main/java/com/nylas/Events.java
+++ b/src/main/java/com/nylas/Events.java
@@ -45,6 +45,22 @@ public class Events extends RestfulDAO<Event> {
 	}
 	
 	public Event update(Event event, boolean notifyParticipants) throws IOException, RequestFailedException {
+		return update(event, null, notifyParticipants);
+	}
+
+	/**
+	 * Update the event with the given id. Useful for updating
+	 * a single instance of a recurring event.
+	 * @param event The event to update
+	 * @param overrideId The ID of the event to update. If null, the ID of the event will be used.
+	 * @param notifyParticipants Whether or not to notify participants of the event update
+	 * @return The updated event
+	 */
+	public Event update(Event event, String overrideId, boolean notifyParticipants) throws IOException, RequestFailedException {
+		if(overrideId != null) {
+			event.setId(overrideId);
+		}
+
 		event.validate();
 		return super.update(event, getExtraQueryParams(notifyParticipants));
 	}

--- a/src/main/java/com/nylas/RestfulModel.java
+++ b/src/main/java/com/nylas/RestfulModel.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public abstract class RestfulModel {
 
-	private String id;
+	String id;
 	
 	private String job_status_id;
 


### PR DESCRIPTION
# Description
This PR adds the ability for a user to pass in an event ID when updating an event, allowing users to pass in the ID of a single recurrence.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.