### PR TITLE
Fix incorrect PKCE code challenge generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 * Fixed issue with sending scheduled messages
+* Fixed incorrect PKCE code challenge generation
 
 ## [2.0.0-beta.3] - Released 2023-12-18
 


### PR DESCRIPTION
# Description
This PR fixes the PKCE code challenge generation; the correct method the API wants is for us to base64 encode the hex string as opposed to base64 encoding resulting hashed bytearray directly.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.