### PR TITLE
Minor model fixes for v2 beta 4

### DIFF
--- a/src/main/kotlin/com/nylas/models/WebhookDeleteResponse.kt
+++ b/src/main/kotlin/com/nylas/models/WebhookDeleteResponse.kt
@@ -1,5 +1,7 @@
 package com.nylas.models
 
+import com.squareup.moshi.Json
+
 /**
  * Class representing a Nylas webhook delete response.
  */
@@ -7,10 +9,12 @@ data class WebhookDeleteResponse(
   /**
    * ID of the request.
    */
+  @Json(name = "request_id")
   val requestId: String,
   /**
    * Object containing the webhook deletion status.
    */
+  @Json(name = "data")
   val data: DataWebhookDeleteData? = null,
 ) {
   /**
@@ -20,6 +24,7 @@ data class WebhookDeleteResponse(
     /**
      * The status of the webhook deletion.
      */
-    val status: Boolean,
+    @Json(name = "status")
+    val status: String,
   )
 }

--- a/src/main/kotlin/com/nylas/util/CreateConnectorAdapter.kt
+++ b/src/main/kotlin/com/nylas/util/CreateConnectorAdapter.kt
@@ -10,7 +10,7 @@ import com.squareup.moshi.*
 class CreateConnectorAdapter {
   @FromJson
   @Throws(UnsupportedOperationException::class)
-  fun fromJson(reader: JsonReader): CreateEventRequest.Conferencing? {
+  fun fromJson(reader: JsonReader): CreateConnectorRequest? {
     throw UnsupportedOperationException("CreateConnectorRequest is only used for serialization")
   }
 


### PR DESCRIPTION
# Description
The following fixes were done:
- Fix `fromJson` error when using CreateConnectorAdapter
- Annotate `WebhookDeleteResponse`

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.