### PR TITLE
Changed clientSecret to optional for token exchange methods; defaults to API Key now 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## [2.0.0-beta.5] - TBD
+
+### Changed
+* Changed `clientSecret` to optional for token exchange methods; defaults to API Key now
+
 ## [2.0.0-beta.4] - Released 2024-01-09
 
 ### BREAKING CHANGES

--- a/src/main/kotlin/com/nylas/models/CodeExchangeRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CodeExchangeRequest.kt
@@ -23,9 +23,10 @@ data class CodeExchangeRequest(
   var clientId: String,
   /**
    * Client secret of the application.
+   * If not provided, the API Key will be used instead.
    */
   @Json(name = "client_secret")
-  var clientSecret: String,
+  var clientSecret: String? = null,
   /**
    * The original plain text code verifier (code_challenge) used in the initial authorization request (PKCE).
    */
@@ -44,15 +45,22 @@ data class CodeExchangeRequest(
    * @param redirectUri Should match the same redirect URI that was used for getting the code during the initial authorization request.
    * @param code OAuth 2.0 code fetched from the previous step.
    * @param clientId Client ID of the application.
-   * @param clientSecret Client secret of the application.
    */
   data class Builder(
     private val redirectUri: String,
     private val code: String,
     private val clientId: String,
-    private val clientSecret: String,
   ) {
+    private var clientSecret: String? = null
     private var codeVerifier: String? = null
+
+    /**
+     * Set the client secret.
+     * If not provided, the API Key will be used instead.
+     * @param clientSecret The client secret.
+     * @return The builder.
+     */
+    fun clientSecret(clientSecret: String) = apply { this.clientSecret = clientSecret }
 
     /**
      * Set the code verifier.

--- a/src/main/kotlin/com/nylas/models/TokenExchangeRequest.kt
+++ b/src/main/kotlin/com/nylas/models/TokenExchangeRequest.kt
@@ -23,13 +23,49 @@ data class TokenExchangeRequest(
   var clientId: String,
   /**
    * Client secret of the application.
+   * If not provided, the API Key will be used instead.
    */
   @Json(name = "client_secret")
-  var clientSecret: String,
+  var clientSecret: String? = null,
 ) {
   /**
    * The grant type for the request. For refreshing tokens, it should always be 'refresh_token'.
    */
   @Json(name = "grant_type")
   private var grantType: String = "refresh_token"
+
+  /**
+   * A builder for creating a [TokenExchangeRequest].
+   *
+   * @param redirectUri Should match the same redirect URI that was used for getting the code during the initial authorization request.
+   * @param refreshToken Token to refresh/request your short-lived access token
+   * @param clientId Client ID of the application.
+   */
+  data class Builder(
+    private val redirectUri: String,
+    private val refreshToken: String,
+    private val clientId: String,
+  ) {
+    private var clientSecret: String? = null
+
+    /**
+     * Set the client secret.
+     * If not provided, the API Key will be used instead.
+     * @param clientSecret The client secret.
+     * @return The builder.
+     */
+    fun clientSecret(clientSecret: String) = apply { this.clientSecret = clientSecret }
+
+    /**
+     * Build the [TokenExchangeRequest].
+     *
+     * @return The [TokenExchangeRequest].
+     */
+    fun build() = TokenExchangeRequest(
+      redirectUri = redirectUri,
+      refreshToken = refreshToken,
+      clientId = clientId,
+      clientSecret = clientSecret,
+    )
+  }
 }

--- a/src/main/kotlin/com/nylas/resources/Auth.kt
+++ b/src/main/kotlin/com/nylas/resources/Auth.kt
@@ -38,6 +38,9 @@ class Auth(private val client: NylasClient) {
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
   fun exchangeCodeForToken(request: CodeExchangeRequest): CodeExchangeResponse {
     val path = "v3/connect/token"
+    if (request.clientSecret == null) {
+      request.clientSecret = client.apiKey
+    }
 
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(CodeExchangeRequest::class.java)
@@ -108,6 +111,9 @@ class Auth(private val client: NylasClient) {
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
   fun refreshAccessToken(request: TokenExchangeRequest): CodeExchangeResponse {
     val path = "v3/connect/token"
+    if (request.clientSecret == null) {
+      request.clientSecret = client.apiKey
+    }
 
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(TokenExchangeRequest::class.java)


### PR DESCRIPTION
# Description
clientSecret is not required if the API Key used for the SDK and the clientId belong to the same application.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.