### PR TITLE
Add default as a type of visibillity

### DIFF
--- a/src/main/kotlin/com/nylas/models/EventVisibility.kt
+++ b/src/main/kotlin/com/nylas/models/EventVisibility.kt
@@ -6,6 +6,9 @@ import com.squareup.moshi.Json
  * Enum representation of visibility of the event, if the event is private or public.
  */
 enum class EventVisibility {
+  @Json(name = "default")
+  DEFAULT,
+
   @Json(name = "public")
   PUBLIC,
 


### PR DESCRIPTION
Default is actually a type of visibility

https://nylas.atlassian.net/browse/TW-2508

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.