### PR TITLE
Fix models for creating drafts and sending messages

### DIFF
--- a/.github/workflows/pull-reqeust.yml
+++ b/.github/workflows/pull-reqeust.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+      - v6.0.0-beta
 
 jobs:
   checks:

--- a/.github/workflows/pull-reqeust.yml
+++ b/.github/workflows/pull-reqeust.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main
-      - v6.0.0-beta
+      - v2.0.0-beta
 
 jobs:
   checks:

--- a/.github/workflows/pull-reqeust.yml
+++ b/.github/workflows/pull-reqeust.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Lint project
+        run: ./gradlew lintKotlin
+
       - name: Build project
         run: ./gradlew clean build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [2.0.0-beta.5] - TBD
 
+### Added
+* Added additional enum support for Grants
+
 ### Changed
 * Changed `clientSecret` to optional for token exchange methods; defaults to API Key now
+* Fixed various issues with the connector API
+* Fixed response type for smart compose methods
+* Fixed inaccuracies with webhook related models
+* Fixed models for creating drafts and sending messages
 
 ## [2.0.0-beta.4] - Released 2024-01-09
 
@@ -15,7 +22,6 @@
 * Added support for sending drafts
 * Added support for the contacts API
 * Added enum support for OAuth prompt
-* Added additional enum support for Grants
 
 ### Changed
 * Fixed issue with sending scheduled messages
@@ -23,9 +29,6 @@
 * Fixed provider detect endpoint path
 * Fixed scope encoding for OAuth URL
 * Fixed typo in 'EventVisibility' enum
-* Fixed various issues with the connector API
-* Fixed response type for smart compose methods
-* Fixed inaccuracies with webhook related models
 
 ## [2.0.0-beta.3] - Released 2023-12-18
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   `java-library`
   application
   signing
+  jacoco
 }
 
 repositories {
@@ -48,7 +49,23 @@ dependencies {
   testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
 }
 
+tasks.jacocoTestReport {
+  classDirectories.setFrom(
+    files(
+      classDirectories.files.map {
+        fileTree(it) {
+          exclude(
+            "com/nylas/models/**",
+            "com/nylas/interceptors/**",
+          )
+        }
+      },
+    ),
+  )
+}
+
 tasks.test {
+  finalizedBy(tasks.jacocoTestReport)
   useJUnitPlatform()
 }
 

--- a/src/main/kotlin/com/nylas/models/CreateDraftRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateDraftRequest.kt
@@ -32,22 +32,10 @@ data class CreateDraftRequest(
   @Transient
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
-   * A short snippet of the message body.
-   * This is the first 100 characters of the message body, with any HTML tags removed.
-   */
-  @Json(name = "snippet")
-  val snippet: String? = null,
-  /**
    * The message subject.
    */
   @Json(name = "subject")
   val subject: String? = null,
-  /**
-   * A reference to the parent thread object.
-   * If this is a new draft, the thread will be empty.
-   */
-  @Json(name = "thread_id")
-  val threadId: String? = null,
   /**
    * The full HTML message body.
    * Messages with only plain-text representations are up-converted to HTML.
@@ -59,11 +47,6 @@ data class CreateDraftRequest(
    */
   @Json(name = "starred")
   val starred: Boolean? = null,
-  /**
-   * Whether or not the message has been read by the user.
-   */
-  @Json(name = "unread")
-  val unread: Boolean? = null,
   /**
    * Unix timestamp to send the message at.
    */
@@ -89,12 +72,9 @@ data class CreateDraftRequest(
     private var cc: List<EmailName>? = null
     private var replyTo: List<EmailName>? = null
     private var attachments: List<CreateAttachmentRequest>? = null
-    private var snippet: String? = null
     private var subject: String? = null
-    private var threadId: String? = null
     private var body: String? = null
     private var starred: Boolean? = null
-    private var unread: Boolean? = null
     private var sendAt: Int? = null
     private var replyToMessageId: String? = null
     private var trackingOptions: TrackingOptions? = null
@@ -135,27 +115,11 @@ data class CreateDraftRequest(
     fun attachments(attachments: List<CreateAttachmentRequest>?) = apply { this.attachments = attachments }
 
     /**
-     * Sets the snippet of the message body.
-     * This is the first 100 characters of the message body, with any HTML tags removed.
-     * @param snippet The snippet of the message body.
-     * @return The builder.
-     */
-    fun snippet(snippet: String?) = apply { this.snippet = snippet }
-
-    /**
      * Sets the message subject.
      * @param subject The message subject.
      * @return The builder.
      */
     fun subject(subject: String?) = apply { this.subject = subject }
-
-    /**
-     * Sets the reference to the parent thread object.
-     * If this is a new draft, the thread will be empty.
-     * @param threadId The reference to the parent thread object.
-     * @return The builder.
-     */
-    fun threadId(threadId: String?) = apply { this.threadId = threadId }
 
     /**
      * Sets the full HTML message body.
@@ -171,13 +135,6 @@ data class CreateDraftRequest(
      * @return The builder.
      */
     fun starred(starred: Boolean?) = apply { this.starred = starred }
-
-    /**
-     * Sets whether or not the message has been read by the user.
-     * @param unread Whether or not the message has been read by the user.
-     * @return The builder.
-     */
-    fun unread(unread: Boolean?) = apply { this.unread = unread }
 
     /**
      * Sets the unix timestamp to send the message at.
@@ -204,21 +161,19 @@ data class CreateDraftRequest(
      * Builds a [SendMessageRequest] instance.
      * @return The [SendMessageRequest] instance.
      */
-    fun build() = CreateDraftRequest(
-      to,
-      bcc,
-      cc,
-      replyTo,
-      attachments,
-      snippet,
-      subject,
-      threadId,
-      body,
-      starred,
-      unread,
-      sendAt,
-      replyToMessageId,
-      trackingOptions,
-    )
+    fun build() =
+      CreateDraftRequest(
+        to,
+        bcc,
+        cc,
+        replyTo,
+        attachments,
+        subject,
+        body,
+        starred,
+        sendAt,
+        replyToMessageId,
+        trackingOptions,
+      )
   }
 }

--- a/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
+++ b/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
@@ -32,22 +32,10 @@ data class SendMessageRequest(
   @Transient
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
-   * A short snippet of the message body.
-   * This is the first 100 characters of the message body, with any HTML tags removed.
-   */
-  @Json(name = "snippet")
-  val snippet: String? = null,
-  /**
    * The message subject.
    */
   @Json(name = "subject")
   val subject: String? = null,
-  /**
-   * A reference to the parent thread object.
-   * If this is a new draft, the thread will be empty.
-   */
-  @Json(name = "thread_id")
-  val threadId: String? = null,
   /**
    * The full HTML message body.
    * Messages with only plain-text representations are up-converted to HTML.
@@ -59,11 +47,6 @@ data class SendMessageRequest(
    */
   @Json(name = "starred")
   val starred: Boolean? = null,
-  /**
-   * Whether or not the message has been read by the user.
-   */
-  @Json(name = "unread")
-  val unread: Boolean? = null,
   /**
    * Unix timestamp to send the message at.
    */
@@ -97,12 +80,9 @@ data class SendMessageRequest(
     private var cc: List<EmailName>? = null
     private var replyTo: List<EmailName>? = null
     private var attachments: List<CreateAttachmentRequest>? = null
-    private var snippet: String? = null
     internal var subject: String? = null
-    private var threadId: String? = null
     private var body: String? = null
     private var starred: Boolean? = null
-    private var unread: Boolean? = null
     private var sendAt: Int? = null
     private var replyToMessageId: String? = null
     private var trackingOptions: TrackingOptions? = null
@@ -137,27 +117,11 @@ data class SendMessageRequest(
     fun attachments(attachments: List<CreateAttachmentRequest>?) = apply { this.attachments = attachments }
 
     /**
-     * Sets the snippet of the message body.
-     * This is the first 100 characters of the message body, with any HTML tags removed.
-     * @param snippet The snippet of the message body.
-     * @return The builder.
-     */
-    fun snippet(snippet: String?) = apply { this.snippet = snippet }
-
-    /**
      * Sets the message subject.
      * @param subject The message subject.
      * @return The builder.
      */
     fun subject(subject: String?) = apply { this.subject = subject }
-
-    /**
-     * Sets the reference to the parent thread object.
-     * If this is a new draft, the thread will be empty.
-     * @param threadId The reference to the parent thread object.
-     * @return The builder.
-     */
-    fun threadId(threadId: String?) = apply { this.threadId = threadId }
 
     /**
      * Sets the full HTML message body.
@@ -173,13 +137,6 @@ data class SendMessageRequest(
      * @return The builder.
      */
     fun starred(starred: Boolean?) = apply { this.starred = starred }
-
-    /**
-     * Sets whether or not the message has been read by the user.
-     * @param unread Whether or not the message has been read by the user.
-     * @return The builder.
-     */
-    fun unread(unread: Boolean?) = apply { this.unread = unread }
 
     /**
      * Sets the unix timestamp to send the message at.
@@ -214,22 +171,20 @@ data class SendMessageRequest(
      * Builds a [SendMessageRequest] instance.
      * @return The [SendMessageRequest] instance.
      */
-    fun build() = SendMessageRequest(
-      to,
-      bcc,
-      cc,
-      replyTo,
-      attachments,
-      snippet,
-      subject,
-      threadId,
-      body,
-      starred,
-      unread,
-      sendAt,
-      replyToMessageId,
-      trackingOptions,
-      useDraft,
-    )
+    fun build() =
+      SendMessageRequest(
+        to,
+        bcc,
+        cc,
+        replyTo,
+        attachments,
+        subject,
+        body,
+        starred,
+        sendAt,
+        replyToMessageId,
+        trackingOptions,
+        useDraft,
+      )
   }
 }

--- a/src/test/kotlin/com/nylas/resources/DraftsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DraftsTests.kt
@@ -44,57 +44,58 @@ class DraftsTests {
     @Test
     fun `Draft serializes properly`() {
       val adapter = JsonHelper.moshi().adapter(Draft::class.java)
-      val jsonBuffer = Buffer().writeUtf8(
-        """
-          {
-            "body": "Hello, I just sent a message using Nylas!",
-            "cc": [
-              {
-                "email": "arya.stark@example.com"
-              }
-            ],
-            "attachments": [
-              {
-                "content_type": "text/calendar",
-                "id": "4kj2jrcoj9ve5j9yxqz5cuv98",
-                "size": 1708
-              }
-            ],
-            "folders": [
-              "8l6c4d11y1p4dm4fxj52whyr9",
-              "d9zkcr2tljpu3m4qpj7l2hbr0"
-            ],
-            "from": [
-              {
-                "name": "Daenerys Targaryen",
-                "email": "daenerys.t@example.com"
-              }
-            ],
-            "grant_id": "41009df5-bf11-4c97-aa18-b285b5f2e386",
-            "id": "5d3qmne77v32r8l4phyuksl2x",
-            "object": "draft",
-            "reply_to": [
-              {
-                "name": "Daenerys Targaryen",
-                "email": "daenerys.t@example.com"
-              }
-            ],
-            "snippet": "Hello, I just sent a message using Nylas!",
-            "starred": true,
-            "subject": "Hello from Nylas!",
-            "thread_id": "1t8tv3890q4vgmwq6pmdwm8qgsaer",
-            "to": [
-              {
-                "name": "Jon Snow",
-                "email": "j.snow@example.com"
-              }
-            ],
-            "date": 1705084742,
-            "created_at": 1705084926
+      val jsonBuffer =
+        Buffer().writeUtf8(
+          """
+            {
+              "body": "Hello, I just sent a message using Nylas!",
+              "cc": [
+                {
+                  "email": "arya.stark@example.com"
+                }
+              ],
+              "attachments": [
+                {
+                  "content_type": "text/calendar",
+                  "id": "4kj2jrcoj9ve5j9yxqz5cuv98",
+                  "size": 1708
+                }
+              ],
+              "folders": [
+                "8l6c4d11y1p4dm4fxj52whyr9",
+                "d9zkcr2tljpu3m4qpj7l2hbr0"
+              ],
+              "from": [
+                {
+                  "name": "Daenerys Targaryen",
+                  "email": "daenerys.t@example.com"
+                }
+              ],
+              "grant_id": "41009df5-bf11-4c97-aa18-b285b5f2e386",
+              "id": "5d3qmne77v32r8l4phyuksl2x",
+              "object": "draft",
+              "reply_to": [
+                {
+                  "name": "Daenerys Targaryen",
+                  "email": "daenerys.t@example.com"
+                }
+              ],
+              "snippet": "Hello, I just sent a message using Nylas!",
+              "starred": true,
+              "subject": "Hello from Nylas!",
+              "thread_id": "1t8tv3890q4vgmwq6pmdwm8qgsaer",
+              "to": [
+                {
+                  "name": "Jon Snow",
+                  "email": "j.snow@example.com"
+                }
+              ],
+              "date": 1705084742,
+              "created_at": 1705084926
+            }
           }
-        }
-        """.trimIndent(),
-      )
+          """.trimIndent(),
+        )
 
       val draft = adapter.fromJson(jsonBuffer)!!
       assertIs<Draft>(draft)
@@ -144,17 +145,18 @@ class DraftsTests {
 
     @Test
     fun `listing drafts calls requests with the correct params`() {
-      val queryParams = ListDraftsQueryParams(
-        limit = 10,
-        threadId = "thread-123",
-        subject = "subject",
-        to = listOf("to"),
-        cc = listOf("cc"),
-        bcc = listOf("bcc"),
-        unread = true,
-        starred = true,
-        hasAttachment = true,
-      )
+      val queryParams =
+        ListDraftsQueryParams(
+          limit = 10,
+          threadId = "thread-123",
+          subject = "subject",
+          to = listOf("to"),
+          cc = listOf("cc"),
+          bcc = listOf("bcc"),
+          unread = true,
+          starred = true,
+          hasAttachment = true,
+        )
 
       drafts.list(grantId, queryParams)
 
@@ -211,34 +213,35 @@ class DraftsTests {
     @Test
     fun `creating a draft calls requests with the correct params`() {
       val adapter = JsonHelper.moshi().adapter(CreateDraftRequest::class.java)
-      val createDraftRequest = CreateDraftRequest(
-        body = "Hello, I just sent a message using Nylas!",
-        cc = listOf(
-          EmailName(
-            email = "test@gmail.com",
-            name = "Test",
-          ),
-        ),
-        bcc = listOf(
-          EmailName(
-            email = "bcc@gmail.com",
-            name = "BCC",
-          ),
-        ),
-        snippet = "Hello, I just sent a message using Nylas!",
-        threadId = "thread-123",
-        subject = "Hello from Nylas!",
-        unread = false,
-        starred = true,
-        sendAt = 1620000000,
-        replyToMessageId = "reply-to-message-id",
-        trackingOptions = TrackingOptions(
-          label = "label",
-          links = true,
-          opens = true,
-          threadReplies = true,
-        ),
-      )
+      val createDraftRequest =
+        CreateDraftRequest(
+          body = "Hello, I just sent a message using Nylas!",
+          cc =
+            listOf(
+              EmailName(
+                email = "test@gmail.com",
+                name = "Test",
+              ),
+            ),
+          bcc =
+            listOf(
+              EmailName(
+                email = "bcc@gmail.com",
+                name = "BCC",
+              ),
+            ),
+          subject = "Hello from Nylas!",
+          starred = true,
+          sendAt = 1620000000,
+          replyToMessageId = "reply-to-message-id",
+          trackingOptions =
+            TrackingOptions(
+              label = "label",
+              links = true,
+              opens = true,
+              threadReplies = true,
+            ),
+        )
 
       drafts.create(grantId, createDraftRequest)
 
@@ -270,12 +273,13 @@ class DraftsTests {
     fun `updating a draft calls requests with the correct params`() {
       val draftId = "draft-123"
       val adapter = JsonHelper.moshi().adapter(UpdateDraftRequest::class.java)
-      val updateDraftRequest = UpdateDraftRequest(
-        body = "Hello, I just sent a message using Nylas!",
-        subject = "Hello from Nylas!",
-        unread = false,
-        starred = true,
-      )
+      val updateDraftRequest =
+        UpdateDraftRequest(
+          body = "Hello, I just sent a message using Nylas!",
+          subject = "Hello from Nylas!",
+          unread = false,
+          starred = true,
+        )
 
       drafts.update(grantId, draftId, updateDraftRequest)
 

--- a/src/test/kotlin/com/nylas/resources/DraftsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DraftsTests.kt
@@ -216,31 +216,13 @@ class DraftsTests {
       val createDraftRequest =
         CreateDraftRequest(
           body = "Hello, I just sent a message using Nylas!",
-          cc =
-            listOf(
-              EmailName(
-                email = "test@gmail.com",
-                name = "Test",
-              ),
-            ),
-          bcc =
-            listOf(
-              EmailName(
-                email = "bcc@gmail.com",
-                name = "BCC",
-              ),
-            ),
+          cc = listOf(EmailName(email = "test@gmail.com", name = "Test")),
+          bcc = listOf(EmailName(email = "bcc@gmail.com", name = "BCC")),
           subject = "Hello from Nylas!",
           starred = true,
           sendAt = 1620000000,
           replyToMessageId = "reply-to-message-id",
-          trackingOptions =
-            TrackingOptions(
-              label = "label",
-              links = true,
-              opens = true,
-              threadReplies = true,
-            ),
+          trackingOptions = TrackingOptions(label = "label", links = true, opens = true, threadReplies = true),
         )
 
       drafts.create(grantId, createDraftRequest)

--- a/src/test/kotlin/com/nylas/resources/MessagesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/MessagesTests.kt
@@ -358,39 +358,15 @@ class MessagesTests {
       val adapter = JsonHelper.moshi().adapter(SendMessageRequest::class.java)
       val sendMessageRequest =
         SendMessageRequest(
-          to =
-            listOf(
-              EmailName(
-                email = "test@gmail.com",
-                name = "Test",
-              ),
-            ),
+          to = listOf(EmailName(email = "test@gmail.com", name = "Test")),
           body = "Hello, I just sent a message using Nylas!",
-          cc =
-            listOf(
-              EmailName(
-                email = "test@gmail.com",
-                name = "Test",
-              ),
-            ),
-          bcc =
-            listOf(
-              EmailName(
-                email = "bcc@gmail.com",
-                name = "BCC",
-              ),
-            ),
+          cc = listOf(EmailName(email = "test@gmail.com", name = "Test")),
+          bcc = listOf(EmailName(email = "bcc@gmail.com", name = "BCC")),
           subject = "Hello from Nylas!",
           starred = true,
           sendAt = 1620000000,
           replyToMessageId = "reply-to-message-id",
-          trackingOptions =
-            TrackingOptions(
-              label = "label",
-              links = true,
-              opens = true,
-              threadReplies = true,
-            ),
+          trackingOptions = TrackingOptions(label = "label", links = true, opens = true, threadReplies = true),
         )
 
       messages.send(grantId, sendMessageRequest)

--- a/src/test/kotlin/com/nylas/resources/MessagesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/MessagesTests.kt
@@ -41,8 +41,9 @@ class MessagesTests {
     @Test
     fun `Message serializes properly`() {
       val adapter = JsonHelper.moshi().adapter(Message::class.java)
-      val jsonBuffer = Buffer().writeUtf8(
-        """
+      val jsonBuffer =
+        Buffer().writeUtf8(
+          """
           {
             "body": "Hello, I just sent a message using Nylas!",
             "cc": [
@@ -90,8 +91,8 @@ class MessagesTests {
             ],
             "unread": true
           }
-        """.trimIndent(),
-      )
+          """.trimIndent(),
+        )
 
       val message = adapter.fromJson(jsonBuffer)!!
       assertIs<Message>(message)
@@ -142,24 +143,25 @@ class MessagesTests {
 
     @Test
     fun `listing messages calls requests with the correct params`() {
-      val queryParams = ListMessagesQueryParams(
-        limit = 10,
-        pageToken = "abc-123",
-        subject = "Hello from Nylas!",
-        anyEmail = listOf("test@gmail.com"),
-        to = listOf("rec@gmail.com"),
-        cc = listOf("cc@gmail.com"),
-        bcc = listOf("bcc@gmail.com"),
-        from = listOf("from@gmail.com"),
-        inFolder = listOf("inbox"),
-        unread = true,
-        starred = true,
-        hasAttachment = true,
-        searchQueryNative = "1634832749",
-        receivedBefore = 1634832749,
-        receivedAfter = 1634832749,
-        fields = MessageFields.INCLUDE_HEADERS,
-      )
+      val queryParams =
+        ListMessagesQueryParams(
+          limit = 10,
+          pageToken = "abc-123",
+          subject = "Hello from Nylas!",
+          anyEmail = listOf("test@gmail.com"),
+          to = listOf("rec@gmail.com"),
+          cc = listOf("cc@gmail.com"),
+          bcc = listOf("bcc@gmail.com"),
+          from = listOf("from@gmail.com"),
+          inFolder = listOf("inbox"),
+          unread = true,
+          starred = true,
+          hasAttachment = true,
+          searchQueryNative = "1634832749",
+          receivedBefore = 1634832749,
+          receivedAfter = 1634832749,
+          fields = MessageFields.INCLUDE_HEADERS,
+        )
 
       messages.list(grantId, queryParams)
 
@@ -219,11 +221,12 @@ class MessagesTests {
     fun `updating a message calls requests with the correct params`() {
       val messageId = "message-123"
       val adapter = JsonHelper.moshi().adapter(UpdateMessageRequest::class.java)
-      val updateMessageRequest = UpdateMessageRequest(
-        starred = true,
-        unread = true,
-        folders = listOf("folder-1", "folder-2"),
-      )
+      val updateMessageRequest =
+        UpdateMessageRequest(
+          starred = true,
+          unread = true,
+          folders = listOf("folder-1", "folder-2"),
+        )
 
       messages.update(grantId, messageId, updateMessageRequest)
 
@@ -353,40 +356,42 @@ class MessagesTests {
     @Test
     fun `sending a message calls requests with the correct params`() {
       val adapter = JsonHelper.moshi().adapter(SendMessageRequest::class.java)
-      val sendMessageRequest = SendMessageRequest(
-        to = listOf(
-          EmailName(
-            email = "test@gmail.com",
-            name = "Test",
-          ),
-        ),
-        body = "Hello, I just sent a message using Nylas!",
-        cc = listOf(
-          EmailName(
-            email = "test@gmail.com",
-            name = "Test",
-          ),
-        ),
-        bcc = listOf(
-          EmailName(
-            email = "bcc@gmail.com",
-            name = "BCC",
-          ),
-        ),
-        snippet = "Hello, I just sent a message using Nylas!",
-        threadId = "thread-123",
-        subject = "Hello from Nylas!",
-        unread = false,
-        starred = true,
-        sendAt = 1620000000,
-        replyToMessageId = "reply-to-message-id",
-        trackingOptions = TrackingOptions(
-          label = "label",
-          links = true,
-          opens = true,
-          threadReplies = true,
-        ),
-      )
+      val sendMessageRequest =
+        SendMessageRequest(
+          to =
+            listOf(
+              EmailName(
+                email = "test@gmail.com",
+                name = "Test",
+              ),
+            ),
+          body = "Hello, I just sent a message using Nylas!",
+          cc =
+            listOf(
+              EmailName(
+                email = "test@gmail.com",
+                name = "Test",
+              ),
+            ),
+          bcc =
+            listOf(
+              EmailName(
+                email = "bcc@gmail.com",
+                name = "BCC",
+              ),
+            ),
+          subject = "Hello from Nylas!",
+          starred = true,
+          sendAt = 1620000000,
+          replyToMessageId = "reply-to-message-id",
+          trackingOptions =
+            TrackingOptions(
+              label = "label",
+              links = true,
+              opens = true,
+              threadReplies = true,
+            ),
+        )
 
       messages.send(grantId, sendMessageRequest)
 


### PR DESCRIPTION
# Description
The model for creating drafts and sending messages had extra fields that are not necessary and confusing, and thus are removed.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.