### PR TITLE
Fix schema issue in the `Event` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nylas Java SDK Changelog
 
+## Unreleased
+
+* Fix schema issue in the `Event` model
+
 ## [2.0.0] - Released 2024-02-05
 
 ### BREAKING CHANGES

--- a/src/main/kotlin/com/nylas/models/Event.kt
+++ b/src/main/kotlin/com/nylas/models/Event.kt
@@ -61,16 +61,6 @@ data class Event(
   @Json(name = "visibility")
   val visibility: EventVisibility = EventVisibility.DEFAULT,
   /**
-   * Unix timestamp when the event was created.
-   */
-  @Json(name = "created_at")
-  val createdAt: Long = 0,
-  /**
-   * Unix timestamp when the event was last updated.
-   */
-  @Json(name = "updated_at")
-  val updatedAt: Long = 0,
-  /**
    * Representation of conferencing details for events. Conferencing object can be in one of two formats (sub-objects):
    * - [Conferencing.Autocreate]
    * - [Conferencing.Details]
@@ -140,6 +130,16 @@ data class Event(
    */
   @Json(name = "capacity")
   val capacity: Int? = null,
+  /**
+   * Unix timestamp when the event was created.
+   */
+  @Json(name = "created_at")
+  val createdAt: Long? = null,
+  /**
+   * Unix timestamp when the event was last updated.
+   */
+  @Json(name = "updated_at")
+  val updatedAt: Long? = null,
 ) {
   /**
    * Get the type of object.


### PR DESCRIPTION
# Description
This PR makes `createdAt` and `updatedAt` optional in the SDK to reflect the API.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.