### PR TITLE
Update FindAttachmentQueryParams to return FindAttachmentQueryParams

### DIFF
--- a/src/main/kotlin/com/nylas/models/FindAttachmentQueryParams.kt
+++ b/src/main/kotlin/com/nylas/models/FindAttachmentQueryParams.kt
@@ -13,17 +13,17 @@ data class FindAttachmentQueryParams(
   val messageId: String,
 ) : IQueryParams {
   /**
-   * Builder for [FindEventQueryParams].
+   * Builder for [FindAttachmentQueryParams].
    * @property messageId Message ID to find the attachment in.
    */
   data class Builder(
     private val messageId: String,
   ) {
     /**
-     * Builds a new [FindEventQueryParams] instance.
-     * @return [FindEventQueryParams]
+     * Builds a new [FindAttachmentQueryParams] instance.
+     * @return [FindAttachmentQueryParams]
      */
-    fun build() = FindEventQueryParams(
+    fun build() = FindAttachmentQueryParams(
       messageId,
     )
   }


### PR DESCRIPTION
Make FindAttachmentQueryParams return FindAttachmentQueryParams

https://nylas.atlassian.net/browse/TW-2559

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.