### PR TITLE
Update Webhooks Rotate Secret path

### DIFF
--- a/src/main/kotlin/com/nylas/resources/Webhooks.kt
+++ b/src/main/kotlin/com/nylas/resources/Webhooks.kt
@@ -78,7 +78,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
    * @returns The updated webhook destination
    */
   fun rotateSecret(webhookId: String): Response<WebhookWithSecret> {
-    val path = String.format("v3/webhooks/%s/rotate-secret", webhookId)
+    val path = String.format("v3/webhooks/rotate-secret/%s", webhookId)
     val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
     return client.executePost(path, responseType)
   }

--- a/src/test/kotlin/com/nylas/resources/WebhooksTests.kt
+++ b/src/test/kotlin/com/nylas/resources/WebhooksTests.kt
@@ -235,7 +235,7 @@ class WebhooksTests {
         queryParamCaptor.capture(),
       )
 
-      assertEquals("v3/webhooks/$webhookId/rotate-secret", pathCaptor.firstValue)
+      assertEquals("v3/webhooks/rotate-secret/$webhookId", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java), typeCaptor.firstValue)
       assertNull(requestBodyCaptor.firstValue)
     }


### PR DESCRIPTION
The Rotate Secret call should webhooks/rotate-secret/id not webhooks/id/rotate-secret

https://nylas.atlassian.net/browse/TW-2580

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.