### PR TITLE
Add DetectProvider to Connectors

### DIFF
--- a/src/main/kotlin/com/nylas/models/ProviderDetectConnectorParams.kt
+++ b/src/main/kotlin/com/nylas/models/ProviderDetectConnectorParams.kt
@@ -1,0 +1,47 @@
+package com.nylas.models
+
+import com.squareup.moshi.Json
+
+/**
+ * Class representing the object used to set parameters for detecting a provider.
+ */
+data class ProviderDetectConnectorParams(
+  /**
+   * Email address to detect the provider for.
+   */
+  @Json(name = "email")
+  val email: String,
+  /**
+   * Search by all providers regardless of created integrations. If unset, defaults to false.
+   */
+  @Json(name = "all_provider_types")
+  val allProviderTypes: Boolean? = null,
+) : IQueryParams {
+  /**
+   * Builder for [ProviderDetectConnectorParams].
+   * @property email Email address to detect the provider for.
+   * @property clientId Client ID of the Nylas application.
+   */
+  data class Builder(
+    private val email: String,
+  ) {
+    private var allProviderTypes: Boolean? = null
+
+    /**
+     * Search by all providers regardless of created integrations
+     * If unset, defaults to false
+     * @param allProviderTypes Search by all providers regardless of created integrations
+     * @return The builder
+     */
+    fun allProviderTypes(allProviderTypes: Boolean?) = apply { this.allProviderTypes = allProviderTypes }
+
+    /**
+     * Build the [ProviderDetectConnectorParams] object
+     * @return The [ProviderDetectConnectorParams] object
+     */
+    fun build() = ProviderDetectConnectorParams(
+      email,
+      allProviderTypes,
+    )
+  }
+}

--- a/src/main/kotlin/com/nylas/resources/Connectors.kt
+++ b/src/main/kotlin/com/nylas/resources/Connectors.kt
@@ -3,6 +3,7 @@ package com.nylas.resources
 import com.nylas.NylasClient
 import com.nylas.models.*
 import com.nylas.util.JsonHelper
+import com.squareup.moshi.Types
 
 class Connectors(client: NylasClient) : Resource<Connector>(client, Connector::class.java) {
   /**
@@ -76,5 +77,18 @@ class Connectors(client: NylasClient) : Resource<Connector>(client, Connector::c
   fun destroy(provider: AuthProvider): DeleteResponse {
     val path = String.format("v3/connectors/%s", provider.value)
     return destroyResource(path)
+  }
+
+  /**
+   * Detect provider from email address
+   * @param params The parameters to include in the request
+   * @return The detected provider, if found
+   */
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  fun detectProvider(params: ProviderDetectConnectorParams): Response<ProviderDetectResponse> {
+    val path = "v3/providers/detect"
+    val responseType = Types.newParameterizedType(Response::class.java, ProviderDetectResponse::class.java)
+
+    return client.executePost(path, responseType, queryParams = params)
   }
 }


### PR DESCRIPTION
DetectProvider is on Auth but should be on Connectors too and Client shouldn’t be a parameter. This add consistency with the Ruby SDK

https://nylas.atlassian.net/browse/TW-2600

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.