### PR TITLE
v2.1 Changes to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Added support for `roundTo` field in availability response
+* Added support for `attributes` field in folder model
 
 ## [2.1.0] - Released 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## Unreleased
+
+### Added
+* Added support for `roundTo` field in availability response
+
 ## [2.1.0] - Released 2024-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 * Added support for `roundTo` field in availability response
 * Added support for `attributes` field in folder model
+* Added support for icloud as an auth provider
 
 ## [2.1.0] - Released 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added support for `roundTo` field in availability response
 * Added support for `attributes` field in folder model
 * Added support for icloud as an auth provider
+* Removed unnecessary `clientId` from detectProvider params
 
 ## [2.1.0] - Released 2024-02-12
 

--- a/src/main/kotlin/com/nylas/models/AuthProvider.kt
+++ b/src/main/kotlin/com/nylas/models/AuthProvider.kt
@@ -17,4 +17,7 @@ enum class AuthProvider(val value: String) {
 
   @Json(name = "virtual-calendar")
   VIRTUAL_CALENDAR("virtual-calendar"),
+
+  @Json(name = "icloud")
+  ICLOUD("icloud"),
 }

--- a/src/main/kotlin/com/nylas/models/Folder.kt
+++ b/src/main/kotlin/com/nylas/models/Folder.kt
@@ -61,6 +61,14 @@ data class Folder(
    */
   @Json(name = "total_count")
   val totalCount: Int? = null,
+  /**
+   * Common attribute descriptors shared by system folders across providers.
+   * For example, Sent email folders have the `["\\Sent"]` attribute.
+   * For IMAP grants, IMAP providers provide the attributes.
+   * For Google and Microsoft Graph, Nylas matches system folders to a set of common attributes.
+   */
+  @Json(name = "attributes")
+  val attributes: List<String>? = null,
 ) {
   /**
    * Get the type of object.

--- a/src/main/kotlin/com/nylas/models/GetAvailabilityRequest.kt
+++ b/src/main/kotlin/com/nylas/models/GetAvailabilityRequest.kt
@@ -37,6 +37,7 @@ data class GetAvailabilityRequest(
    * When set to true, the availability time slots will start at 30 minutes past or on the hour.
    * For example, a free slot starting at 16:10 is considered available only from 16:30.
    */
+  @Deprecated("Use roundTo instead")
   @Json(name = "round_to_30_minutes")
   val roundTo30Minutes: Boolean? = null,
   /**
@@ -44,6 +45,14 @@ data class GetAvailabilityRequest(
    */
   @Json(name = "availability_rules")
   val availabilityRules: AvailabilityRules? = null,
+  /**
+   * The number of minutes to round the time slots to.
+   * This allows for rounding to any multiple of 5 minutes, up to a maximum of 60 minutes.
+   * The default value is set to 15 minutes.
+   * When this variable is assigned a value, it overrides the behavior of the [roundTo30Minutes] flag, if it was set.
+   */
+  @Json(name = "round_to")
+  val roundTo: Int? = null,
 ) {
   /**
    * A builder for creating a [GetAvailabilityRequest].
@@ -62,6 +71,7 @@ data class GetAvailabilityRequest(
     private var intervalMinutes: Int? = null
     private var roundTo30Minutes: Boolean? = null
     private var availabilityRules: AvailabilityRules? = null
+    private var roundTo: Int? = null
 
     /**
      * Set the Nylas checks from the nearest interval of the passed [startTime].
@@ -78,6 +88,7 @@ data class GetAvailabilityRequest(
      * @param roundTo30Minutes When set to true, the availability time slots will start at 30 minutes past or on the hour.
      * @return The builder.
      */
+    @Deprecated("Use roundTo instead")
     fun roundTo30Minutes(roundTo30Minutes: Boolean) = apply { this.roundTo30Minutes = roundTo30Minutes }
 
     /**
@@ -86,6 +97,16 @@ data class GetAvailabilityRequest(
      * @return The builder.
      */
     fun availabilityRules(availabilityRules: AvailabilityRules) = apply { this.availabilityRules = availabilityRules }
+
+    /**
+     * Set the number of minutes to round the time slots to.
+     * This allows for rounding to any multiple of 5 minutes, up to a maximum of 60 minutes.
+     * The default value is set to 15 minutes.
+     * When this variable is assigned a value, it overrides the behavior of the [roundTo30Minutes] flag, if it was set.
+     * @param roundTo The number of minutes to round the time slots to.
+     * @return The builder.
+     */
+    fun roundTo(roundTo: Int) = apply { this.roundTo = roundTo }
 
     /**
      * Build the [GetAvailabilityRequest].
@@ -99,6 +120,7 @@ data class GetAvailabilityRequest(
       intervalMinutes,
       roundTo30Minutes,
       availabilityRules,
+      roundTo,
     )
   }
 }

--- a/src/main/kotlin/com/nylas/models/ProviderDetectParams.kt
+++ b/src/main/kotlin/com/nylas/models/ProviderDetectParams.kt
@@ -12,11 +12,6 @@ data class ProviderDetectParams(
   @Json(name = "email")
   val email: String,
   /**
-   * Client ID of the Nylas application.
-   */
-  @Json(name = "client_id")
-  var clientId: String,
-  /**
    * Search by all providers regardless of created integrations. If unset, defaults to false.
    */
   @Json(name = "all_provider_types")
@@ -25,11 +20,9 @@ data class ProviderDetectParams(
   /**
    * Builder for [ProviderDetectParams].
    * @property email Email address to detect the provider for.
-   * @property clientId Client ID of the Nylas application.
    */
   data class Builder(
     private val email: String,
-    private val clientId: String,
   ) {
     private var allProviderTypes: Boolean? = null
 
@@ -47,7 +40,6 @@ data class ProviderDetectParams(
      */
     fun build() = ProviderDetectParams(
       email,
-      clientId,
       allProviderTypes,
     )
   }

--- a/src/test/kotlin/com/nylas/resources/AuthTests.kt
+++ b/src/test/kotlin/com/nylas/resources/AuthTests.kt
@@ -275,7 +275,6 @@ class AuthTests {
     fun `detectProvider calls requests with the correct params`() {
       val request = ProviderDetectParams(
         email = "test@nylas.com",
-        clientId = "abc-123",
         allProviderTypes = true,
       )
 

--- a/src/test/kotlin/com/nylas/resources/FoldersTests.kt
+++ b/src/test/kotlin/com/nylas/resources/FoldersTests.kt
@@ -54,7 +54,8 @@ class FoldersTests {
             "parent_id": "ascsf21412",
             "background_color": "#039BE5",
             "text_color": "#039BE5",
-            "total_count": 0
+            "total_count": 0,
+            "attributes": ["\\SENT"]
           }
         """.trimIndent(),
       )
@@ -72,6 +73,7 @@ class FoldersTests {
       assertEquals("#039BE5", folder.backgroundColor)
       assertEquals("#039BE5", folder.textColor)
       assertEquals(0, folder.totalCount)
+      assertEquals(listOf("\\SENT"), folder.attributes)
     }
   }
 


### PR DESCRIPTION
# Description
* Added support for `roundTo` field in availability response model
* Added support for `attributes` field in folder model
* Added support for icloud as an auth provider
* Removed `clientId` from `detectProvider`

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.