### PR TITLE
Improved message sending and draft create/update performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## Unreleased
+
+### Changed
+* Improved message sending and draft create/update performance
+
 ## [2.2.0] - Released 2024-02-27
 
 ### Added

--- a/src/main/kotlin/com/nylas/resources/Drafts.kt
+++ b/src/main/kotlin/com/nylas/resources/Drafts.kt
@@ -47,7 +47,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
     // Use form data only if the attachment size is greater than 3mb
     val attachmentSize = requestBody.attachments?.sumOf { it.size } ?: 0
 
-    return if (attachmentSize >= FileUtils.FORM_DATA_ATTACHMENT_SIZE) {
+    return if (attachmentSize >= FileUtils.MAXIMUM_JSON_ATTACHMENT_SIZE) {
       val attachmentLessPayload = requestBody.copy(attachments = null)
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
@@ -75,7 +75,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
     // Use form data only if the attachment size is greater than 3mb
     val attachmentSize = requestBody.attachments?.sumOf { it.size } ?: 0
 
-    return if (attachmentSize >= FileUtils.FORM_DATA_ATTACHMENT_SIZE) {
+    return if (attachmentSize >= FileUtils.MAXIMUM_JSON_ATTACHMENT_SIZE) {
       val attachmentLessPayload = requestBody.copy(attachments = null)
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)

--- a/src/main/kotlin/com/nylas/resources/Messages.kt
+++ b/src/main/kotlin/com/nylas/resources/Messages.kt
@@ -82,7 +82,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
     // Use form data only if the attachment size is greater than 3mb
     val attachmentSize = requestBody.attachments?.sumOf { it.size } ?: 0
 
-    return if (attachmentSize >= FileUtils.FORM_DATA_ATTACHMENT_SIZE) {
+    return if (attachmentSize >= FileUtils.MAXIMUM_JSON_ATTACHMENT_SIZE) {
       val attachmentLessPayload = requestBody.copy(attachments = null)
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)

--- a/src/main/kotlin/com/nylas/util/FileUtils.kt
+++ b/src/main/kotlin/com/nylas/util/FileUtils.kt
@@ -14,6 +14,9 @@ import java.nio.file.Paths
 
 class FileUtils {
   companion object {
+    @JvmStatic
+    val FORM_DATA_ATTACHMENT_SIZE = 3 * 1024 * 1024
+
     /**
      * Converts an [InputStream] into a streaming [RequestBody] for use with [okhttp3] requests.
      *

--- a/src/main/kotlin/com/nylas/util/FileUtils.kt
+++ b/src/main/kotlin/com/nylas/util/FileUtils.kt
@@ -14,8 +14,11 @@ import java.nio.file.Paths
 
 class FileUtils {
   companion object {
+    /**
+     * The maximum size of an attachment that can be sent using json.
+     */
     @JvmStatic
-    val FORM_DATA_ATTACHMENT_SIZE = 3 * 1024 * 1024
+    val MAXIMUM_JSON_ATTACHMENT_SIZE = 3 * 1024 * 1024
 
     /**
      * Converts an [InputStream] into a streaming [RequestBody] for use with [okhttp3] requests.


### PR DESCRIPTION
# Description
This PR improves message send/draft create/update performance by always defaulting to application/json instead of multipart. Multipart will only be used for when a request contains a total attachments size of 3mb or higher.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.