### PR TITLE
Change default timeout to match API (90 seconds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## Unreleased
+
+### Changed
+* Change default timeout to match API (90 seconds)
+
 ## [2.2.0] - Released 2024-02-27
 
 ### Added

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -477,9 +477,9 @@ class NylasClient(
      *
      * By default, the NylasClient configures it as follows:
      * .protocols(Arrays.asList(Protocol.HTTP_1_1))
-     * .connectTimeout(60, TimeUnit.SECONDS)
-     * .readTimeout(60, TimeUnit.SECONDS)
-     * .writeTimeout(60,  TimeUnit.SECONDS)
+     * .connectTimeout(90, TimeUnit.SECONDS)
+     * .readTimeout(90, TimeUnit.SECONDS)
+     * .writeTimeout(90,  TimeUnit.SECONDS)
      * .addNetworkInterceptor(new HttpLoggingInterceptor()
      *
      * @param httpClient The custom OkHttpClient.Builder to use.
@@ -500,9 +500,9 @@ class NylasClient(
     val DEFAULT_BASE_URL = Region.US.nylasApiUrl
     private fun defaultHttpClient(): OkHttpClient.Builder {
       return OkHttpClient.Builder()
-        .connectTimeout(60, TimeUnit.SECONDS)
-        .readTimeout(60, TimeUnit.SECONDS)
-        .writeTimeout(60, TimeUnit.SECONDS)
+        .connectTimeout(90, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .writeTimeout(90, TimeUnit.SECONDS)
         .protocols(listOf(Protocol.HTTP_1_1))
         .addNetworkInterceptor(HttpLoggingInterceptor())
     }


### PR DESCRIPTION
# Description
The API's default timeout is 90 seconds, so it's best we match that. We have updated the default value to match this, user can still override the default.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.