### PR TITLE
Add support for custom headers field for drafts and messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+### [Unreleased]
+
+### Added
+* Add support for custom headers field for Drafts and Messages
+
 ## [2.2.1] - Released 2024-03-05
 
 ### Changed

--- a/src/main/kotlin/com/nylas/models/CreateDraftRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateDraftRequest.kt
@@ -62,6 +62,11 @@ data class CreateDraftRequest(
    */
   @Json(name = "tracking_options")
   val trackingOptions: TrackingOptions? = null,
+  /**
+   * A list of custom headers to add to the message.
+   */
+  @Json(name = "custom_headers")
+  val customHeaders: List<CustomHeader>? = null,
 ) : IMessageAttachmentRequest {
   /**
    * Builder for [CreateDraftRequest].
@@ -78,6 +83,7 @@ data class CreateDraftRequest(
     private var sendAt: Int? = null
     private var replyToMessageId: String? = null
     private var trackingOptions: TrackingOptions? = null
+    private var customHeaders: List<CustomHeader>? = null
 
     /**
      * Sets the recipients.
@@ -158,6 +164,13 @@ data class CreateDraftRequest(
     fun trackingOptions(trackingOptions: TrackingOptions?) = apply { this.trackingOptions = trackingOptions }
 
     /**
+     * Sets the custom headers to add to the message.
+     * @param customHeaders The custom headers to add to the message.
+     * @return The builder.
+     */
+    fun customHeaders(customHeaders: List<CustomHeader>?) = apply { this.customHeaders = customHeaders }
+
+    /**
      * Builds a [SendMessageRequest] instance.
      * @return The [SendMessageRequest] instance.
      */
@@ -174,6 +187,7 @@ data class CreateDraftRequest(
         sendAt,
         replyToMessageId,
         trackingOptions,
+        customHeaders,
       )
   }
 }

--- a/src/main/kotlin/com/nylas/models/CustomHeader.kt
+++ b/src/main/kotlin/com/nylas/models/CustomHeader.kt
@@ -1,0 +1,36 @@
+package com.nylas.models
+
+import com.squareup.moshi.Json
+
+/**
+ * Custom headers to be used when drafting or sending an email.
+ */
+data class CustomHeader(
+  /**
+   * The name of the custom header.
+   */
+  @Json(name = "name")
+  val name: String,
+  /**
+   * The value of the custom header.
+   */
+  @Json(name = "value")
+  val value: String,
+) {
+  /**
+   * Builder for [CustomHeader].
+   * @property name The name of the custom header.
+   * @property value The value of the custom header.
+   */
+  data class Builder(
+    private val name: String,
+    private val value: String,
+  ) {
+    /**
+     * Build the [CustomHeader] object.
+     */
+    fun build(): CustomHeader {
+      return CustomHeader(name, value)
+    }
+  }
+}

--- a/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
+++ b/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
@@ -68,6 +68,11 @@ data class SendMessageRequest(
    */
   @Json(name = "use_draft")
   val useDraft: Boolean? = null,
+  /**
+   * A list of custom headers to add to the message.
+   */
+  @Json(name = "custom_headers")
+  val customHeaders: List<CustomHeader>? = null,
 ) : IMessageAttachmentRequest {
   /**
    * Builder for [SendMessageRequest].
@@ -87,6 +92,7 @@ data class SendMessageRequest(
     private var replyToMessageId: String? = null
     private var trackingOptions: TrackingOptions? = null
     private var useDraft: Boolean? = null
+    private var customHeaders: List<CustomHeader>? = null
 
     /**
      * Sets the bcc recipients.
@@ -168,6 +174,13 @@ data class SendMessageRequest(
     fun useDraft(useDraft: Boolean?) = apply { this.useDraft = useDraft }
 
     /**
+     * Sets the custom headers to add to the message.
+     * @param customHeaders The custom headers to add to the message.
+     * @return The builder.
+     */
+    fun customHeaders(customHeaders: List<CustomHeader>?) = apply { this.customHeaders = customHeaders }
+
+    /**
      * Builds a [SendMessageRequest] instance.
      * @return The [SendMessageRequest] instance.
      */
@@ -185,6 +198,7 @@ data class SendMessageRequest(
         replyToMessageId,
         trackingOptions,
         useDraft,
+        customHeaders,
       )
   }
 }

--- a/src/test/kotlin/com/nylas/resources/DraftsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DraftsTests.kt
@@ -224,6 +224,7 @@ class DraftsTests {
           sendAt = 1620000000,
           replyToMessageId = "reply-to-message-id",
           trackingOptions = TrackingOptions(label = "label", links = true, opens = true, threadReplies = true),
+          customHeaders = listOf(CustomHeader(name = "header", value = "value")),
         )
 
       drafts.create(grantId, createDraftRequest)
@@ -267,6 +268,7 @@ class DraftsTests {
               size = 100,
             ),
           ),
+          customHeaders = listOf(CustomHeader(name = "header", value = "value")),
         )
 
       drafts.create(grantId, createDraftRequest)
@@ -310,6 +312,7 @@ class DraftsTests {
               size = 3 * 1024 * 1024,
             ),
           ),
+          customHeaders = listOf(CustomHeader(name = "header", value = "value")),
         )
 
       drafts.create(grantId, createDraftRequest)

--- a/src/test/kotlin/com/nylas/resources/MessagesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/MessagesTests.kt
@@ -368,6 +368,7 @@ class MessagesTests {
           sendAt = 1620000000,
           replyToMessageId = "reply-to-message-id",
           trackingOptions = TrackingOptions(label = "label", links = true, opens = true, threadReplies = true),
+          customHeaders = listOf(CustomHeader(name = "header-name", value = "header-value")),
         )
 
       messages.send(grantId, sendMessageRequest)
@@ -412,6 +413,7 @@ class MessagesTests {
               size = 100,
             ),
           ),
+          customHeaders = listOf(CustomHeader(name = "header-name", value = "header-value")),
         )
 
       messages.send(grantId, sendMessageRequest)
@@ -456,6 +458,7 @@ class MessagesTests {
               size = 3 * 1024 * 1024,
             ),
           ),
+          customHeaders = listOf(CustomHeader(name = "header-name", value = "header-value")),
         )
 
       messages.send(grantId, sendMessageRequest)


### PR DESCRIPTION
# Description
This PR adds support to the custom headers field used to attach headers to message and draft objects.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.