### PR TITLE
Added support for overriding various fields of outgoing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## Unreleased
+
+### Added
+* Added support for overriding various fields of outgoing requests
+
 ## [2.2.1] - Released 2024-03-05
 
 ### Changed

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -305,9 +305,13 @@ class NylasClient(
     url: HttpUrl.Builder,
     method: HttpMethod,
     body: RequestBody?,
+    userHeaders: Map<String, String> = emptyMap(),
   ): Request {
     val builder = Request.Builder().url(url.build())
     builder.addHeader(HttpHeaders.AUTHORIZATION.headerName, "Bearer $apiKey")
+    for ((key, value) in userHeaders) {
+      builder.addHeader(key, value)
+    }
     return builder.method(method.toString(), body).build()
   }
 

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -188,6 +188,7 @@ class NylasClient(
    * @param path The path to request.
    * @param resultType The type of the response body.
    * @param queryParams The query parameters.
+   * @param overrides The request overrides.
    * @suppress Not for public use.
    */
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -207,6 +208,7 @@ class NylasClient(
    * @param resultType The type of the response body.
    * @param requestBody The request body.
    * @param queryParams The query parameters.
+   * @param overrides The request overrides.
    * @suppress Not for public use.
    */
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -228,6 +230,7 @@ class NylasClient(
    * @param resultType The type of the response body.
    * @param requestBody The request body.
    * @param queryParams The query parameters.
+   * @param overrides The request overrides.
    * @suppress Not for public use.
    */
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -249,6 +252,7 @@ class NylasClient(
    * @param resultType The type of the response body.
    * @param requestBody The request body.
    * @param queryParams The query parameters.
+   * @param overrides The request overrides.
    * @suppress Not for public use.
    */
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -272,6 +276,7 @@ class NylasClient(
    * @param path The path to request.
    * @param resultType The type of the response body.
    * @param queryParams The query parameters.
+   * @param overrides The request overrides.
    * @suppress Not for public use.
    */
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -292,6 +297,7 @@ class NylasClient(
    * @param requestBody The form-data request body.
    * @param resultType The type of the response body.
    * @param queryParams The query parameters.
+   * @param overrides The request overrides.
    * @suppress Not for public use.
    */
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)

--- a/src/main/kotlin/com/nylas/models/RequestOverrides.kt
+++ b/src/main/kotlin/com/nylas/models/RequestOverrides.kt
@@ -15,7 +15,7 @@ data class RequestOverrides(
   /**
    * The timeout to use for the request.
    */
-  val timeout: Int? = null,
+  val timeout: Long? = null,
   /**
    * Additional headers to include in the request.
    */
@@ -27,7 +27,7 @@ data class RequestOverrides(
   class Builder {
     private var apiKey: String? = null
     private var apiUri: String? = null
-    private var timeout: Int? = null
+    private var timeout: Long? = null
     private var headers: Map<String, String>? = null
 
     /**
@@ -43,7 +43,7 @@ data class RequestOverrides(
     /**
      * Set the timeout to use for the request.
      */
-    fun timeout(timeout: Int) = apply { this.timeout = timeout }
+    fun timeout(timeout: Long) = apply { this.timeout = timeout }
 
     /**
      * Add additional headers to include in the request.

--- a/src/main/kotlin/com/nylas/models/RequestOverrides.kt
+++ b/src/main/kotlin/com/nylas/models/RequestOverrides.kt
@@ -1,0 +1,58 @@
+package com.nylas.models
+
+/**
+ * Overrides to use for an outgoing request to the Nylas API.
+ */
+data class RequestOverrides(
+  /**
+   * The API key to use for the request.
+   */
+  val apiKey: String? = null,
+  /**
+   * The API URI to use for the request.
+   */
+  val apiUri: String? = null,
+  /**
+   * The timeout to use for the request.
+   */
+  val timeout: Int? = null,
+  /**
+   * Additional headers to include in the request.
+   */
+  val headers: Map<String, String>? = emptyMap(),
+) {
+  /**
+   * Builder for [RequestOverrides].
+   */
+  class Builder {
+    private var apiKey: String? = null
+    private var apiUri: String? = null
+    private var timeout: Int? = null
+    private var headers: Map<String, String>? = null
+
+    /**
+     * Set the API key to use for the request.
+     */
+    fun apiKey(apiKey: String) = apply { this.apiKey = apiKey }
+
+    /**
+     * Set the API URI to use for the request.
+     */
+    fun apiUri(apiUri: String) = apply { this.apiUri = apiUri }
+
+    /**
+     * Set the timeout to use for the request.
+     */
+    fun timeout(timeout: Int) = apply { this.timeout = timeout }
+
+    /**
+     * Add additional headers to include in the request.
+     */
+    fun headers(headers: Map<String, String>) = apply { this.headers = headers }
+
+    /**
+     * Build the [RequestOverrides].
+     */
+    fun build() = RequestOverrides(apiKey, apiUri, timeout, headers)
+  }
+}

--- a/src/main/kotlin/com/nylas/resources/Applications.kt
+++ b/src/main/kotlin/com/nylas/resources/Applications.kt
@@ -1,10 +1,7 @@
 package com.nylas.resources
 
 import com.nylas.NylasClient
-import com.nylas.models.ApplicationDetails
-import com.nylas.models.NylasApiError
-import com.nylas.models.NylasSdkTimeoutError
-import com.nylas.models.Response
+import com.nylas.models.*
 import com.squareup.moshi.Types
 
 /**
@@ -23,12 +20,14 @@ class Applications(private val client: NylasClient) {
 
   /**
    * Get application details
+   * @param overrides Optional request overrides to apply
    * @return The application details
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun getDetails(): Response<ApplicationDetails> {
+  @JvmOverloads
+  fun getDetails(overrides: RequestOverrides? = null): Response<ApplicationDetails> {
     val path = "v3/applications"
     val responseType = Types.newParameterizedType(Response::class.java, ApplicationDetails::class.java)
-    return client.executeGet(path, responseType)
+    return client.executeGet(path, responseType, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Attachments.kt
+++ b/src/main/kotlin/com/nylas/resources/Attachments.kt
@@ -17,12 +17,14 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
    * @param identifier Grant ID or email account to query
    * @param attachmentId The id of the attachment to retrieve.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The attachment metadata
    */
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams): Response<Attachment> {
+  @JvmOverloads
+  fun find(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): Response<Attachment> {
     val path = String.format("v3/grants/%s/attachments/%s", identifier, attachmentId)
-    return findResource(path, queryParams)
+    return findResource(path, queryParams, overrides = overrides)
   }
 
   /**
@@ -37,13 +39,15 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
    * @param identifier Grant ID or email account to query
    * @param attachmentId The id of the attachment to download.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The [ResponseBody] containing the file data
    */
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
-  fun download(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams): ResponseBody {
+  @JvmOverloads
+  fun download(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): ResponseBody {
     val path = String.format("v3/grants/%s/attachments/%s/download", identifier, attachmentId)
 
-    return client.downloadResponse(path, queryParams)
+    return client.downloadResponse(path, queryParams, overrides = overrides)
   }
 
   /**
@@ -51,11 +55,13 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
    * @param identifier Grant ID or email account to query
    * @param attachmentId The id of the attachment to download.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The raw file data
    */
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
-  fun downloadBytes(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams): ByteArray {
-    val download = download(identifier, attachmentId, queryParams)
+  @JvmOverloads
+  fun downloadBytes(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): ByteArray {
+    val download = download(identifier, attachmentId, queryParams, overrides = overrides)
     val fileBytes = download.bytes()
     download.close()
     return fileBytes

--- a/src/main/kotlin/com/nylas/resources/Attachments.kt
+++ b/src/main/kotlin/com/nylas/resources/Attachments.kt
@@ -61,7 +61,7 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun downloadBytes(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): ByteArray {
-    val download = download(identifier, attachmentId, queryParams, overrides = overrides)
+    val download = download(identifier, attachmentId, queryParams, overrides)
     val fileBytes = download.bytes()
     download.close()
     return fileBytes

--- a/src/main/kotlin/com/nylas/resources/Auth.kt
+++ b/src/main/kotlin/com/nylas/resources/Auth.kt
@@ -33,10 +33,12 @@ class Auth(private val client: NylasClient) {
   /**
    * Exchange an authorization code for an access token
    * @param request The code exchange request
+   * @param overrides Optional request overrides to apply
    * @return The response containing the access token
    */
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
-  fun exchangeCodeForToken(request: CodeExchangeRequest): CodeExchangeResponse {
+  @JvmOverloads
+  fun exchangeCodeForToken(request: CodeExchangeRequest, overrides: RequestOverrides? = null): CodeExchangeResponse {
     val path = "v3/connect/token"
     if (request.clientSecret == null) {
       request.clientSecret = client.apiKey
@@ -46,7 +48,7 @@ class Auth(private val client: NylasClient) {
       .adapter(CodeExchangeRequest::class.java)
       .toJson(request)
 
-    return client.executePost(path, CodeExchangeResponse::class.java, serializedRequestBody)
+    return client.executePost(path, CodeExchangeResponse::class.java, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -90,26 +92,30 @@ class Auth(private val client: NylasClient) {
   /**
    * Create a grant via custom authentication
    * @param requestBody The values to create the grant with
+   * @param overrides Optional request overrides to apply
    * @return The created grant
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun customAuthentication(requestBody: CreateGrantRequest): Response<Grant> {
+  @JvmOverloads
+  fun customAuthentication(requestBody: CreateGrantRequest, overrides: RequestOverrides? = null): Response<Grant> {
     val path = "v3/connect/custom"
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(CreateGrantRequest::class.java)
       .toJson(requestBody)
     val responseType = Types.newParameterizedType(Response::class.java, Grant::class.java)
 
-    return client.executePost(path, responseType, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Refresh an access token
    * @param request The refresh token request
+   * @param overrides Optional request overrides to apply
    * @return The response containing the new access token
    */
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
-  fun refreshAccessToken(request: TokenExchangeRequest): CodeExchangeResponse {
+  @JvmOverloads
+  fun refreshAccessToken(request: TokenExchangeRequest, overrides: RequestOverrides? = null): CodeExchangeResponse {
     val path = "v3/connect/token"
     if (request.clientSecret == null) {
       request.clientSecret = client.apiKey
@@ -119,18 +125,20 @@ class Auth(private val client: NylasClient) {
       .adapter(TokenExchangeRequest::class.java)
       .toJson(request)
 
-    return client.executePost(path, CodeExchangeResponse::class.java, serializedRequestBody)
+    return client.executePost(path, CodeExchangeResponse::class.java, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Revoke a token (and the grant attached to the token)
    * @param token The token to revoke
+   * @param overrides Optional request overrides to apply
    * @return True if the token was revoked successfully
    */
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
-  fun revoke(token: String): Boolean {
+  @JvmOverloads
+  fun revoke(token: String, overrides: RequestOverrides? = null): Boolean {
     val path = "v3/connect/revoke?token=$token"
-    client.executePost<Any>(path, MutableMap::class.java)
+    client.executePost<Any>(path, MutableMap::class.java, overrides = overrides)
 
     return true
   }
@@ -138,36 +146,42 @@ class Auth(private val client: NylasClient) {
   /**
    * Detect provider from email address
    * @param params The parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The detected provider, if found
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun detectProvider(params: ProviderDetectParams): Response<ProviderDetectResponse> {
+  @JvmOverloads
+  fun detectProvider(params: ProviderDetectParams, overrides: RequestOverrides? = null): Response<ProviderDetectResponse> {
     val path = "v3/providers/detect"
     val responseType = Types.newParameterizedType(Response::class.java, ProviderDetectResponse::class.java)
 
-    return client.executePost(path, responseType, queryParams = params)
+    return client.executePost(path, responseType, queryParams = params, overrides = overrides)
   }
 
   /**
    * Get info about an ID token
    * @param idToken The ID token to query
+   * @param overrides Optional request overrides to apply
    * @return The token information
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun idTokenInfo(idToken: String): Response<TokenInfoResponse> {
+  @JvmOverloads
+  fun idTokenInfo(idToken: String, overrides: RequestOverrides? = null): Response<TokenInfoResponse> {
     val params = TokenInfoRequest(idToken = idToken)
-    return getTokenInfo(params)
+    return getTokenInfo(params, overrides)
   }
 
   /**
    * Get info about an access token
    * @param accessToken The access token to query
+   * @param overrides Optional request overrides to apply
    * @return The token information
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun accessTokenInfo(accessToken: String): Response<TokenInfoResponse> {
+  @JvmOverloads
+  fun accessTokenInfo(accessToken: String, overrides: RequestOverrides? = null): Response<TokenInfoResponse> {
     val params = TokenInfoRequest(accessToken = accessToken)
-    return getTokenInfo(params)
+    return getTokenInfo(params, overrides)
   }
 
   /**
@@ -203,9 +217,9 @@ class Auth(private val client: NylasClient) {
     return url
   }
 
-  private fun getTokenInfo(params: TokenInfoRequest): Response<TokenInfoResponse> {
+  private fun getTokenInfo(params: TokenInfoRequest, overrides: RequestOverrides?): Response<TokenInfoResponse> {
     val path = "v3/connect/tokeninfo"
     val responseType = Types.newParameterizedType(Response::class.java, TokenInfoResponse::class.java)
-    return client.executeGet(path, responseType, queryParams = params)
+    return client.executeGet(path, responseType, queryParams = params, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Calendars.kt
+++ b/src/main/kotlin/com/nylas/resources/Calendars.kt
@@ -19,39 +19,44 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
    * Return all Calendars
    * @param identifier Grant ID or email account to query.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Calendars
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(identifier: String, queryParams: ListCalendersQueryParams? = null): ListResponse<Calendar> {
+  fun list(identifier: String, queryParams: ListCalendersQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Calendar> {
     val path = String.format("v3/grants/%s/calendars", identifier)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Calendar
    * @param identifier Grant ID or email account to query.
    * @param calendarId The id of the Calendar to retrieve. Use "primary" to refer to the primary calendar associated with grant.
+   * @param overrides Optional request overrides to apply
    * @return The calendar
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, calendarId: String): Response<Calendar> {
+  @JvmOverloads
+  fun find(identifier: String, calendarId: String, overrides: RequestOverrides? = null): Response<Calendar> {
     val path = String.format("v3/grants/%s/calendars/%s", identifier, calendarId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a Calendar
    * @param identifier Grant ID or email account in which to create the object.
    * @param requestBody The values to create the calendar with
+   * @param overrides Optional request overrides to apply
    * @return The created calendar
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(identifier: String, requestBody: CreateCalendarRequest): Response<Calendar> {
+  @JvmOverloads
+  fun create(identifier: String, requestBody: CreateCalendarRequest, overrides: RequestOverrides? = null): Response<Calendar> {
     val path = String.format("v3/grants/%s/calendars", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateCalendarRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody)
+    return createResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -59,35 +64,40 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
    * @param identifier Grant ID or email account in which to update an object.
    * @param calendarId The id of the calendar to update. Use "primary" to refer to the primary calendar associated with grant.
    * @param requestBody The values to update the calendar with
+   * @param overrides Optional request overrides to apply
    * @return The updated calendar
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, calendarId: String, requestBody: UpdateCalendarRequest): Response<Calendar> {
+  @JvmOverloads
+  fun update(identifier: String, calendarId: String, requestBody: UpdateCalendarRequest, overrides: RequestOverrides? = null): Response<Calendar> {
     val path = String.format("v3/grants/%s/calendars/%s", identifier, calendarId)
     val adapter = JsonHelper.moshi().adapter(UpdateCalendarRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody)
+    return updateResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Calendar
    * @param identifier Grant ID or email account from which to delete an object.
    * @param calendarId The id of the Calendar to delete. Use "primary" to refer to the primary calendar associated with grant.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, calendarId: String): DeleteResponse {
+  fun destroy(identifier: String, calendarId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/calendars/%s", identifier, calendarId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 
   /**
    * Get Availability for a given account / accounts
    * @param request The availability request
+   * @param overrides Optional request overrides to apply
    * @return The availability response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun getAvailability(request: GetAvailabilityRequest): Response<GetAvailabilityResponse> {
+  @JvmOverloads
+  fun getAvailability(request: GetAvailabilityRequest, overrides: RequestOverrides? = null): Response<GetAvailabilityResponse> {
     val path = "v3/calendars/availability"
 
     val serializedRequestBody = JsonHelper.moshi()
@@ -96,17 +106,19 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
 
     val responseType = Types.newParameterizedType(Response::class.java, GetAvailabilityResponse::class.java)
 
-    return client.executePost(path, responseType, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Get the free/busy schedule for a list of email addresses
    * @param identifier The identifier of the grant to act upon
    * @param request The free/busy request
+   * @param overrides Optional request overrides to apply
    * @return The free/busy response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun getFreeBusy(identifier: String, request: GetFreeBusyRequest): Response<List<GetFreeBusyResponse>> {
+  @JvmOverloads
+  fun getFreeBusy(identifier: String, request: GetFreeBusyRequest, overrides: RequestOverrides? = null): Response<List<GetFreeBusyResponse>> {
     val path = String.format("v3/grants/%s/calendars/free-busy", identifier)
 
     val serializedRequestBody = JsonHelper.moshi()
@@ -115,6 +127,6 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
 
     val responseType = Types.newParameterizedType(Response::class.java, GET_FREE_BUSY_RESPONSE_ADAPTER)
 
-    return client.executePost(path, responseType, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Connectors.kt
+++ b/src/main/kotlin/com/nylas/resources/Connectors.kt
@@ -16,65 +16,74 @@ class Connectors(client: NylasClient) : Resource<Connector>(client, Connector::c
   /**
    * Return all Connectors
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Connectors
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(queryParams: ListConnectorsQueryParams? = null): ListResponse<Connector> {
+  fun list(queryParams: ListConnectorsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Connector> {
     val path = "v3/connectors"
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Connector
    * @param provider The provider associated to the connector to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Connector
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(provider: AuthProvider): Response<Connector> {
+  @JvmOverloads
+  fun find(provider: AuthProvider, overrides: RequestOverrides? = null): Response<Connector> {
     val path = String.format("v3/connectors/%s", provider.value)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a Connector
    * @param requestBody The values to create the Connector with
+   * @param overrides Optional request overrides to apply
    * @return The created Connector
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(requestBody: CreateConnectorRequest): Response<Connector> {
+  @JvmOverloads
+  fun create(requestBody: CreateConnectorRequest, overrides: RequestOverrides? = null): Response<Connector> {
     val path = "v3/connectors"
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(CreateConnectorRequest::class.java)
       .toJson(requestBody)
 
-    return createResource(path, serializedRequestBody)
+    return createResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Update a Connector
    * @param provider The provider associated to the connector to update.
    * @param requestBody The values to update the Connector with
+   * @param overrides Optional request overrides to apply
    * @return The updated Connector
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(provider: AuthProvider, requestBody: UpdateConnectorRequest): Response<Connector> {
+  @JvmOverloads
+  fun update(provider: AuthProvider, requestBody: UpdateConnectorRequest, overrides: RequestOverrides? = null): Response<Connector> {
     val path = String.format("v3/connectors/%s", provider.value)
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(UpdateConnectorRequest::class.java)
       .toJson(requestBody)
 
-    return patchResource(path, serializedRequestBody)
+    return patchResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Connector
    * @param provider The provider associated to the connector to update.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(provider: AuthProvider): DeleteResponse {
+  @JvmOverloads
+  fun destroy(provider: AuthProvider, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/connectors/%s", provider.value)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Contacts.kt
+++ b/src/main/kotlin/com/nylas/resources/Contacts.kt
@@ -10,13 +10,14 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
    * Return all contacts
    * @param identifier The identifier of the grant to act upon
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of contacts
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(identifier: String, queryParams: ListContactsQueryParams? = null): ListResponse<Contact> {
+  fun list(identifier: String, queryParams: ListContactsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Contact> {
     val path = String.format("v3/grants/%s/contacts", identifier)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
@@ -24,27 +25,30 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
    * @param identifier The identifier of the grant to act upon
    * @param contactId The id of the contact to retrieve.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The contact
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun find(identifier: String, contactId: String, queryParams: FindContactQueryParams? = null): Response<Contact> {
+  fun find(identifier: String, contactId: String, queryParams: FindContactQueryParams? = null, overrides: RequestOverrides? = null): Response<Contact> {
     val path = String.format("v3/grants/%s/contacts/%s", identifier, contactId)
-    return findResource(path, queryParams)
+    return findResource(path, queryParams, overrides)
   }
 
   /**
    * Create a Contact
    * @param identifier Grant ID or email account in which to create the object
    * @param requestBody The values to create the event with
+   * @param overrides Optional request overrides to apply
    * @return The created contact
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(identifier: String, requestBody: CreateContactRequest): Response<Contact> {
+  @JvmOverloads
+  fun create(identifier: String, requestBody: CreateContactRequest, overrides: RequestOverrides? = null): Response<Contact> {
     val path = String.format("v3/grants/%s/contacts", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateContactRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody)
+    return createResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -52,39 +56,44 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
    * @param identifier The identifier of the grant to act upon
    * @param contactId The id of the contact to update.
    * @param requestBody The values to update the Contact with
+   * @param overrides Optional request overrides to apply
    * @return The updated contact
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, contactId: String, requestBody: UpdateContactRequest): Response<Contact> {
+  @JvmOverloads
+  fun update(identifier: String, contactId: String, requestBody: UpdateContactRequest, overrides: RequestOverrides? = null): Response<Contact> {
     val path = String.format("v3/grants/%s/contacts/%s", identifier, contactId)
     val adapter = JsonHelper.moshi().adapter(UpdateContactRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody)
+    return updateResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Contact
    * @param identifier The identifier of the grant to act upon
    * @param contactId The id of the Contact to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, contactId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(identifier: String, contactId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/contacts/%s", identifier, contactId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 
   /**
    * Return all contact groups
    * @param identifier The identifier of the grant to act upon
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The scheduled message
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun listGroups(identifier: String, queryParams: ListContactGroupsQueryParams? = null): ListResponse<ContactGroup> {
+  fun listGroups(identifier: String, queryParams: ListContactGroupsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<ContactGroup> {
     val path = String.format("v3/grants/%s/contacts/groups", identifier)
     val responseType = Types.newParameterizedType(ListResponse::class.java, ContactGroup::class.java)
-    return client.executeGet(path, responseType, queryParams)
+    return client.executeGet(path, responseType, queryParams, overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Credentials.kt
+++ b/src/main/kotlin/com/nylas/resources/Credentials.kt
@@ -9,41 +9,46 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
    * Return all Credentials
    * @param provider The provider associated to the credential to list from
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Credentials
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(provider: AuthProvider, queryParams: ListCredentialsQueryParams? = null): ListResponse<Credential> {
+  fun list(provider: AuthProvider, queryParams: ListCredentialsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Credential> {
     val path = String.format("v3/connectors/%s/creds", provider.value)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Credential
    * @param provider The provider associated to the connector to retrieve.
    * @param credentialsId The id of the credentials to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Credential
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(provider: AuthProvider, credentialsId: String): Response<Credential> {
+  @JvmOverloads
+  fun find(provider: AuthProvider, credentialsId: String, overrides: RequestOverrides? = null): Response<Credential> {
     val path = String.format("v3/connectors/%s/creds/%s", provider.value, credentialsId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a Credential
    * @param provider The provider associated to the credential being created.
    * @param requestBody The values to create the Credential with
+   * @param overrides Optional request overrides to apply
    * @return The created Credential
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(provider: AuthProvider, requestBody: CreateCredentialRequest): Response<Credential> {
+  @JvmOverloads
+  fun create(provider: AuthProvider, requestBody: CreateCredentialRequest, overrides: RequestOverrides? = null): Response<Credential> {
     val path = String.format("v3/connectors/%s/creds", provider.value)
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(CreateCredentialRequest::class.java)
       .toJson(requestBody)
 
-    return createResource(path, serializedRequestBody)
+    return createResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -51,27 +56,31 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
    * @param provider The provider associated to the connector to update from.
    * @param credentialsId The id of the credentials to retrieve.
    * @param requestBody The id of the credentials to update
+   * @param overrides Optional request overrides to apply
    * @return The updated Credential
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(provider: AuthProvider, credentialsId: String, requestBody: UpdateCredentialRequest): Response<Credential> {
+  @JvmOverloads
+  fun update(provider: AuthProvider, credentialsId: String, requestBody: UpdateCredentialRequest, overrides: RequestOverrides? = null): Response<Credential> {
     val path = String.format("v3/connectors/%s/creds/%s", provider.value, credentialsId)
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(UpdateCredentialRequest::class.java)
       .toJson(requestBody)
 
-    return patchResource(path, serializedRequestBody)
+    return patchResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Credential
    * @param provider The provider associated to the connector to delete.
    * @param credentialsId The id of the credentials to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(provider: AuthProvider, credentialsId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(provider: AuthProvider, credentialsId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/connectors/%s/creds/%s", provider.value, credentialsId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Drafts.kt
+++ b/src/main/kotlin/com/nylas/resources/Drafts.kt
@@ -11,35 +11,40 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
    * Return all Drafts
    * @param identifier The identifier of the grant to act upon
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Drafts
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(identifier: String, queryParams: ListDraftsQueryParams? = null): ListResponse<Draft> {
+  fun list(identifier: String, queryParams: ListDraftsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Draft> {
     val path = String.format("v3/grants/%s/drafts", identifier)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Draft
    * @param identifier The identifier of the grant to act upon
    * @param draftId The id of the Draft to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Draft
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, draftId: String): Response<Draft> {
+  @JvmOverloads
+  fun find(identifier: String, draftId: String, overrides: RequestOverrides? = null): Response<Draft> {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, draftId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a Draft
    * @param identifier The identifier of the grant to act upon
    * @param requestBody The values to create the Draft with
+   * @param overrides Optional request overrides to apply
    * @return The updated Draft
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(identifier: String, requestBody: CreateDraftRequest): Response<Draft> {
+  @JvmOverloads
+  fun create(identifier: String, requestBody: CreateDraftRequest, overrides: RequestOverrides? = null): Response<Draft> {
     val path = String.format("v3/grants/%s/drafts", identifier)
     val responseType = Types.newParameterizedType(Response::class.java, Draft::class.java)
     val adapter = JsonHelper.moshi().adapter(CreateDraftRequest::class.java)
@@ -52,10 +57,10 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
 
-      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType)
+      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      createResource(path, serializedRequestBody)
+      createResource(path, serializedRequestBody, overrides = overrides)
     }
   }
 
@@ -64,10 +69,12 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
    * @param identifier The identifier of the grant to act upon
    * @param draftId The id of the Draft to update.
    * @param requestBody The values to update the Draft with
+   * @param overrides Optional request overrides to apply
    * @return The updated Draft
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, draftId: String, requestBody: UpdateDraftRequest): Response<Draft> {
+  @JvmOverloads
+  fun update(identifier: String, draftId: String, requestBody: UpdateDraftRequest, overrides: RequestOverrides? = null): Response<Draft> {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, draftId)
     val responseType = Types.newParameterizedType(Response::class.java, Draft::class.java)
     val adapter = JsonHelper.moshi().adapter(UpdateDraftRequest::class.java)
@@ -80,10 +87,10 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
 
-      client.executeFormRequest(path, NylasClient.HttpMethod.PUT, multipart, responseType)
+      client.executeFormRequest(path, NylasClient.HttpMethod.PUT, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      updateResource(path, serializedRequestBody)
+      updateResource(path, serializedRequestBody, overrides = overrides)
     }
   }
 
@@ -91,24 +98,28 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
    * Delete a Draft
    * @param identifier The identifier of the grant to act upon
    * @param draftId The id of the Draft to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, draftId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(identifier: String, draftId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, draftId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 
   /**
    * Send a Draft
    * @param identifier The identifier of the grant to act upon
    * @param draftId The id of the Draft to send.
+   * @param overrides Optional request overrides to apply
    * @return The sent Draft
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun send(identifier: String, draftId: String): Response<Message> {
+  @JvmOverloads
+  fun send(identifier: String, draftId: String, overrides: RequestOverrides? = null): Response<Message> {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, draftId)
     val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
-    return client.executePost(path, responseType)
+    return client.executePost(path, responseType, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Events.kt
+++ b/src/main/kotlin/com/nylas/resources/Events.kt
@@ -16,12 +16,14 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
    * Return all Events
    * @param identifier Grant ID or email account to query
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of events
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun list(identifier: String, queryParams: ListEventQueryParams): ListResponse<Event> {
+  @JvmOverloads
+  fun list(identifier: String, queryParams: ListEventQueryParams, overrides: RequestOverrides? = null): ListResponse<Event> {
     val path = String.format("v3/grants/%s/events", identifier)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
@@ -29,12 +31,14 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
    * @param identifier Grant ID or email account to query
    * @param eventId The id of the event to retrieve.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The event
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, eventId: String, queryParams: FindEventQueryParams): Response<Event> {
+  @JvmOverloads
+  fun find(identifier: String, eventId: String, queryParams: FindEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
     val path = String.format("v3/grants/%s/events/%s", identifier, eventId)
-    return findResource(path, queryParams)
+    return findResource(path, queryParams, overrides)
   }
 
   /**
@@ -42,14 +46,16 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
    * @param identifier Grant ID or email account in which to create the object
    * @param requestBody The values to create the event with
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The created event
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(identifier: String, requestBody: CreateEventRequest, queryParams: CreateEventQueryParams): Response<Event> {
+  @JvmOverloads
+  fun create(identifier: String, requestBody: CreateEventRequest, queryParams: CreateEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
     val path = String.format("v3/grants/%s/events", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateEventRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, queryParams)
+    return createResource(path, serializedRequestBody, queryParams, overrides)
   }
 
   /**
@@ -58,14 +64,16 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
    * @param eventId The id of the event to update.
    * @param requestBody The values to update the Event with
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The updated event
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, eventId: String, requestBody: UpdateEventRequest, queryParams: UpdateEventQueryParams): Response<Event> {
+  @JvmOverloads
+  fun update(identifier: String, eventId: String, requestBody: UpdateEventRequest, queryParams: UpdateEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
     val path = String.format("v3/grants/%s/events/%s", identifier, eventId)
     val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, queryParams)
+    return updateResource(path, serializedRequestBody, queryParams, overrides)
   }
 
   /**
@@ -73,12 +81,14 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
    * @param identifier The identifier of the grant to act upon
    * @param eventId The id of the event to delete.
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, eventId: String, queryParams: DestroyEventQueryParams): DeleteResponse {
+  @JvmOverloads
+  fun destroy(identifier: String, eventId: String, queryParams: DestroyEventQueryParams, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/events/%s", identifier, eventId)
-    return destroyResource(path, queryParams)
+    return destroyResource(path, queryParams, overrides)
   }
 
   /**
@@ -87,14 +97,16 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
    * @param eventId The id of the Event to update.
    * @param requestBody The values to send the RSVP with
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The send-rsvp response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun sendRsvp(identifier: String, eventId: String, requestBody: SendRsvpRequest, queryParams: SendRsvpQueryParams): DeleteResponse {
+  @JvmOverloads
+  fun sendRsvp(identifier: String, eventId: String, requestBody: SendRsvpRequest, queryParams: SendRsvpQueryParams, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/events/%s/send-rsvp", identifier, eventId)
     val adapter = JsonHelper.moshi().adapter(SendRsvpRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
 
-    return client.executePost(path, DeleteResponse::class.java, serializedRequestBody, queryParams)
+    return client.executePost(path, DeleteResponse::class.java, serializedRequestBody, queryParams, overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Folders.kt
+++ b/src/main/kotlin/com/nylas/resources/Folders.kt
@@ -8,38 +8,44 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   /**
    * Return all Folders
    * @param identifier Grant ID or email account to query.
+   * @param overrides Optional request overrides to apply
    * @return The list of Folders
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun list(identifier: String): ListResponse<Folder> {
+  @JvmOverloads
+  fun list(identifier: String, overrides: RequestOverrides? = null): ListResponse<Folder> {
     val path = String.format("v3/grants/%s/folders", identifier)
-    return listResource(path)
+    return listResource(path, overrides = overrides)
   }
 
   /**
    * Return a Folder
    * @param identifier Grant ID or email account to query.
    * @param folderId The id of the folder to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The folder
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, folderId: String): Response<Folder> {
+  @JvmOverloads
+  fun find(identifier: String, folderId: String, overrides: RequestOverrides? = null): Response<Folder> {
     val path = String.format("v3/grants/%s/folders/%s", identifier, folderId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a Folder
    * @param identifier Grant ID or email account in which to create the object.
    * @param requestBody The values to create the folder with
+   * @param overrides Optional request overrides to apply
    * @return The created folder
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(identifier: String, requestBody: CreateFolderRequest): Response<Folder> {
+  @JvmOverloads
+  fun create(identifier: String, requestBody: CreateFolderRequest, overrides: RequestOverrides? = null): Response<Folder> {
     val path = String.format("v3/grants/%s/folders", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateFolderRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody)
+    return createResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -47,25 +53,29 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
    * @param identifier Grant ID or email account in which to update an object.
    * @param folderId The id of the folder to update.
    * @param requestBody The values to update the folder with
+   * @param overrides Optional request overrides to apply
    * @return The updated folder
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, folderId: String, requestBody: UpdateFolderRequest): Response<Folder> {
+  @JvmOverloads
+  fun update(identifier: String, folderId: String, requestBody: UpdateFolderRequest, overrides: RequestOverrides? = null): Response<Folder> {
     val path = String.format("v3/grants/%s/folders/%s", identifier, folderId)
     val adapter = JsonHelper.moshi().adapter(UpdateFolderRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody)
+    return updateResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Folder
    * @param identifier Grant ID or email account from which to delete an object.
    * @param folderId The id of the folder to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, folderId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(identifier: String, folderId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/folders/%s", identifier, folderId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Grants.kt
+++ b/src/main/kotlin/com/nylas/resources/Grants.kt
@@ -15,50 +15,57 @@ class Grants(client: NylasClient) : Resource<Grant>(client, Grant::class.java) {
   /**
    * Return all Grants
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Grants
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(queryParams: ListGrantsQueryParams? = null): ListResponse<Grant> {
+  fun list(queryParams: ListGrantsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Grant> {
     val path = "v3/grants"
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Grant
    * @param grantId The id of the Grant to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Grant
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(grantId: String): Response<Grant> {
+  @JvmOverloads
+  fun find(grantId: String, overrides: RequestOverrides? = null): Response<Grant> {
     val path = String.format("v3/grants/%s", grantId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Update a Grant
    * @param grantId The id of the Grant to update.
    * @param requestBody The values to update the Grant with
+   * @param overrides Optional request overrides to apply
    * @return The updated Grant
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(grantId: String, requestBody: UpdateGrantRequest): Response<Grant> {
+  @JvmOverloads
+  fun update(grantId: String, requestBody: UpdateGrantRequest, overrides: RequestOverrides? = null): Response<Grant> {
     val path = String.format("v3/grants/%s", grantId)
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(UpdateGrantRequest::class.java)
       .toJson(requestBody)
 
-    return patchResource(path, serializedRequestBody)
+    return patchResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Grant
    * @param grantId The id of the Grant to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(grantId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(grantId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s", grantId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Messages.kt
+++ b/src/main/kotlin/com/nylas/resources/Messages.kt
@@ -19,25 +19,28 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
    * Return all Messages
    * @param identifier The identifier of the grant to act upon
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Messages
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(identifier: String, queryParams: ListMessagesQueryParams? = null): ListResponse<Message> {
+  fun list(identifier: String, queryParams: ListMessagesQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Message> {
     val path = String.format("v3/grants/%s/messages", identifier)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Message
    * @param identifier The identifier of the grant to act upon
    * @param messageId The id of the Message to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Message
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, messageId: String): Response<Message> {
+  @JvmOverloads
+  fun find(identifier: String, messageId: String, overrides: RequestOverrides? = null): Response<Message> {
     val path = String.format("v3/grants/%s/messages/%s", identifier, messageId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
@@ -45,36 +48,42 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
    * @param identifier The identifier of the grant to act upon
    * @param messageId The id of the Message to update.
    * @param requestBody The values to update the Message with
+   * @param overrides Optional request overrides to apply
    * @return The updated Message
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, messageId: String, requestBody: UpdateMessageRequest): Response<Message> {
+  @JvmOverloads
+  fun update(identifier: String, messageId: String, requestBody: UpdateMessageRequest, overrides: RequestOverrides? = null): Response<Message> {
     val path = String.format("v3/grants/%s/messages/%s", identifier, messageId)
     val adapter = JsonHelper.moshi().adapter(UpdateMessageRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody)
+    return updateResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Message
    * @param identifier The identifier of the grant to act upon
    * @param messageId The id of the Message to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, messageId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(identifier: String, messageId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/messages/%s", identifier, messageId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 
   /**
    * Send an email
    * @param identifier The identifier of the grant to act upon
    * @param requestBody The values to send the email with
+   * @param overrides Optional request overrides to apply
    * @return The sent email
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun send(identifier: String, requestBody: SendMessageRequest): Response<Message> {
+  @JvmOverloads
+  fun send(identifier: String, requestBody: SendMessageRequest, overrides: RequestOverrides? = null): Response<Message> {
     val path = String.format("v3/grants/%s/messages/send", identifier)
     val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
     val adapter = JsonHelper.moshi().adapter(SendMessageRequest::class.java)
@@ -87,48 +96,53 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
 
-      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType)
+      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      createResource(path, serializedRequestBody)
+      createResource(path, serializedRequestBody, overrides = overrides)
     }
   }
 
   /**
    * Retrieve your scheduled messages
    * @param identifier The identifier of the grant to act upon
+   * @param overrides Optional request overrides to apply
    * @return The list of scheduled messages
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun listScheduledMessages(identifier: String): Response<ScheduledMessagesList> {
+  @JvmOverloads
+  fun listScheduledMessages(identifier: String, overrides: RequestOverrides? = null): Response<ScheduledMessagesList> {
     val path = String.format("v3/grants/%s/messages/schedules", identifier)
     val responseType = Types.newParameterizedType(Response::class.java, ScheduledMessagesList::class.java)
-    return client.executeGet(path, responseType)
+    return client.executeGet(path, responseType, overrides = overrides)
   }
 
   /**
    * Retrieve a scheduled message
    * @param identifier The identifier of the grant to act upon
    * @param scheduleId The id of the scheduled message to retrieve
+   * @param overrides Optional request overrides to apply
    * @return The scheduled message
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun findScheduledMessage(identifier: String, scheduleId: String): Response<ScheduledMessage> {
+  @JvmOverloads
+  fun findScheduledMessage(identifier: String, scheduleId: String, overrides: RequestOverrides? = null): Response<ScheduledMessage> {
     val path = String.format("v3/grants/%s/messages/schedules/%s", identifier, scheduleId)
     val responseType = Types.newParameterizedType(Response::class.java, ScheduledMessage::class.java)
-    return client.executeGet(path, responseType)
+    return client.executeGet(path, responseType, overrides = overrides)
   }
 
   /**
    * Stop a scheduled message
    * @param identifier The identifier of the grant to act upon
    * @param scheduleId The id of the scheduled message to stop
+   * @param overrides Optional request overrides to apply
    * @return The confirmation of the stopped scheduled message
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun stopScheduledMessage(identifier: String, scheduleId: String): Response<StopScheduledMessageResponse> {
+  fun stopScheduledMessage(identifier: String, scheduleId: String, overrides: RequestOverrides? = null): Response<StopScheduledMessageResponse> {
     val path = String.format("v3/grants/%s/messages/schedules/%s", identifier, scheduleId)
     val responseType = Types.newParameterizedType(Response::class.java, StopScheduledMessageResponse::class.java)
-    return client.executeDelete(path, responseType)
+    return client.executeDelete(path, responseType, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/RedirectUris.kt
+++ b/src/main/kotlin/com/nylas/resources/RedirectUris.kt
@@ -14,64 +14,74 @@ import com.nylas.util.JsonHelper
 class RedirectUris(client: NylasClient) : Resource<RedirectUri>(client, RedirectUri::class.java) {
   /**
    * Return all Redirect URIs
+   * @param overrides Optional request overrides to apply
    * @return The list of Redirect URIs
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun list(): ListResponse<RedirectUri> {
+  @JvmOverloads
+  fun list(overrides: RequestOverrides? = null): ListResponse<RedirectUri> {
     val path = "v3/applications/redirect-uris"
-    return listResource(path)
+    return listResource(path, overrides = overrides)
   }
 
   /**
    * Return a Redirect URI
    * @param redirectUriId The id of the Redirect URI to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Redirect URI
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(redirectUriId: String): Response<RedirectUri> {
+  @JvmOverloads
+  fun find(redirectUriId: String, overrides: RequestOverrides? = null): Response<RedirectUri> {
     val path = String.format("v3/applications/redirect-uris/%s", redirectUriId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a Redirect URI
    * @param requestBody The values to create the Redirect URI with
+   * @param overrides Optional request overrides to apply
    * @return The created Redirect URI
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(requestBody: CreateRedirectUriRequest): Response<RedirectUri> {
+  @JvmOverloads
+  fun create(requestBody: CreateRedirectUriRequest, overrides: RequestOverrides? = null): Response<RedirectUri> {
     val path = "v3/applications/redirect-uris"
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(CreateRedirectUriRequest::class.java)
       .toJson(requestBody)
 
-    return createResource(path, serializedRequestBody)
+    return createResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Update a Redirect URI
    * @param redirectUriId The id of the Redirect URI to update.
    * @param requestBody The values to update the Redirect URI with
+   * @param overrides Optional request overrides to apply
    * @return The updated Redirect URI
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(redirectUriId: String, requestBody: UpdateRedirectUriRequest): Response<RedirectUri> {
+  @JvmOverloads
+  fun update(redirectUriId: String, requestBody: UpdateRedirectUriRequest, overrides: RequestOverrides? = null): Response<RedirectUri> {
     val path = String.format("v3/applications/redirect-uris/%s", redirectUriId)
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(UpdateRedirectUriRequest::class.java)
       .toJson(requestBody)
 
-    return patchResource(path, serializedRequestBody)
+    return patchResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Redirect URI
    * @param redirectUriId The id of the Redirect URI to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deleted Redirect URI
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(redirectUriId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(redirectUriId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/applications/redirect-uris/%s", redirectUriId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Resource.kt
+++ b/src/main/kotlin/com/nylas/resources/Resource.kt
@@ -14,40 +14,36 @@ abstract class Resource<T> protected constructor(
   protected val client: NylasClient,
   modelClass: Class<T>,
 ) {
-  private val responseType: Type
-  private val listResponseType: Type
-  init {
-    responseType = Types.newParameterizedType(Response::class.java, modelClass)
-    listResponseType = Types.newParameterizedType(ListResponse::class.java, modelClass)
+  private val responseType: Type = Types.newParameterizedType(Response::class.java, modelClass)
+  private val listResponseType: Type = Types.newParameterizedType(ListResponse::class.java, modelClass)
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun listResource(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<T> {
+    return client.executeGet(path, listResponseType, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
-  protected fun listResource(path: String, queryParams: IQueryParams? = null): ListResponse<T> {
-    return client.executeGet(path, listResponseType, queryParams)
+  protected fun findResource(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executeGet(path, responseType, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
-  protected fun findResource(path: String, queryParams: IQueryParams? = null): Response<T> {
-    return client.executeGet(path, responseType, queryParams)
+  protected fun createResource(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executePost(path, responseType, requestBody, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
-  protected fun createResource(path: String, requestBody: String?, queryParams: IQueryParams? = null): Response<T> {
-    return client.executePost(path, responseType, requestBody, queryParams)
+  protected fun updateResource(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executePut(path, responseType, requestBody, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
-  protected fun updateResource(path: String, requestBody: String?, queryParams: IQueryParams? = null): Response<T> {
-    return client.executePut(path, responseType, requestBody, queryParams)
+  protected fun patchResource(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executePatch(path, responseType, requestBody, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
-  protected fun patchResource(path: String, requestBody: String?, queryParams: IQueryParams? = null): Response<T> {
-    return client.executePatch(path, responseType, requestBody, queryParams)
-  }
-
-  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
-  protected fun destroyResource(path: String, queryParams: IQueryParams? = null): DeleteResponse {
-    return client.executeDelete(path, DeleteResponse::class.java, queryParams)
+  protected fun destroyResource(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): DeleteResponse {
+    return client.executeDelete(path, DeleteResponse::class.java, queryParams, overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/SmartCompose.kt
+++ b/src/main/kotlin/com/nylas/resources/SmartCompose.kt
@@ -1,11 +1,10 @@
 package com.nylas.resources
 
 import com.nylas.NylasClient
-import com.nylas.models.ComposeMessageRequest
-import com.nylas.models.ComposeMessageResponse
-import com.nylas.models.Response
+import com.nylas.models.*
 import com.nylas.util.JsonHelper
 import com.squareup.moshi.Types
+import kotlin.jvm.Throws
 
 /**
  * A collection of Smart Compose related API endpoints.
@@ -17,11 +16,14 @@ import com.squareup.moshi.Types
 class SmartCompose(private val client: NylasClient) {
   /**
    * Compose a message
-   * @property identifier The identifier of the grant to act upon
-   * @property requestBody The prompt that smart compose will use to generate a message suggestion
+   * @param identifier The identifier of the grant to act upon
+   * @param requestBody The prompt that smart compose will use to generate a message suggestion
+   * @param overrides Optional request overrides to apply
    * @return The generated message
    */
-  fun composeMessage(identifier: String, requestBody: ComposeMessageRequest): Response<ComposeMessageResponse> {
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  @JvmOverloads
+  fun composeMessage(identifier: String, requestBody: ComposeMessageRequest, overrides: RequestOverrides? = null): Response<ComposeMessageResponse> {
     val path = "v3/grants/$identifier/messages/smart-compose"
 
     val serializedRequestBody = JsonHelper.moshi()
@@ -29,17 +31,20 @@ class SmartCompose(private val client: NylasClient) {
       .toJson(requestBody)
     val responseType = Types.newParameterizedType(Response::class.java, ComposeMessageResponse::class.java)
 
-    return client.executePost(path, responseType, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Compose a message reply
-   * @property identifier The identifier of the grant to act upon
-   * @property messageId The id of the message to reply to
-   * @property requestBody The prompt that smart compose will use to generate a reply suggestion
+   * @param identifier The identifier of the grant to act upon
+   * @param messageId The id of the message to reply to
+   * @param requestBody The prompt that smart compose will use to generate a reply suggestion
+   * @param overrides Optional request overrides to apply
    * @return The generated message reply
    */
-  fun composeMessageReply(identifier: String, messageId: String, requestBody: ComposeMessageRequest): Response<ComposeMessageResponse> {
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  @JvmOverloads
+  fun composeMessageReply(identifier: String, messageId: String, requestBody: ComposeMessageRequest, overrides: RequestOverrides? = null): Response<ComposeMessageResponse> {
     val path = "v3/grants/$identifier/messages/$messageId/smart-compose"
 
     val serializedRequestBody = JsonHelper.moshi()
@@ -47,6 +52,6 @@ class SmartCompose(private val client: NylasClient) {
       .toJson(requestBody)
     val responseType = Types.newParameterizedType(Response::class.java, ComposeMessageResponse::class.java)
 
-    return client.executePost(path, responseType, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Threads.kt
+++ b/src/main/kotlin/com/nylas/resources/Threads.kt
@@ -9,25 +9,28 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
    * Return all Threads
    * @param identifier The identifier of the grant to act upon
    * @param queryParams The query parameters to include in the request
+   * @param overrides Optional request overrides to apply
    * @return The list of Threads
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun list(identifier: String, queryParams: ListThreadsQueryParams? = null): ListResponse<Thread> {
+  fun list(identifier: String, queryParams: ListThreadsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Thread> {
     val path = String.format("v3/grants/%s/threads", identifier)
-    return listResource(path, queryParams)
+    return listResource(path, queryParams, overrides)
   }
 
   /**
    * Return a Thread
    * @param identifier The identifier of the grant to act upon
    * @param threadId The id of the Thread to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The Thread
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(identifier: String, threadId: String): Response<Thread> {
+  @JvmOverloads
+  fun find(identifier: String, threadId: String, overrides: RequestOverrides? = null): Response<Thread> {
     val path = String.format("v3/grants/%s/threads/%s", identifier, threadId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
@@ -35,25 +38,29 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
    * @param identifier The identifier of the grant to act upon
    * @param threadId The id of the Thread to update.
    * @param requestBody The values to update the Thread with
+   * @param overrides Optional request overrides to apply
    * @return The updated Thread
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(identifier: String, threadId: String, requestBody: UpdateThreadRequest): Response<Thread> {
+  @JvmOverloads
+  fun update(identifier: String, threadId: String, requestBody: UpdateThreadRequest, overrides: RequestOverrides? = null): Response<Thread> {
     val path = String.format("v3/grants/%s/threads/%s", identifier, threadId)
     val adapter = JsonHelper.moshi().adapter(UpdateThreadRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody)
+    return updateResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a Thread
    * @param identifier The identifier of the grant to act upon
    * @param threadId The id of the Thread to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deletion response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(identifier: String, threadId: String): DeleteResponse {
+  @JvmOverloads
+  fun destroy(identifier: String, threadId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/threads/%s", identifier, threadId)
-    return destroyResource(path)
+    return destroyResource(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Webhooks.kt
+++ b/src/main/kotlin/com/nylas/resources/Webhooks.kt
@@ -15,82 +15,99 @@ import java.util.*
 class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.java) {
   /**
    * List all webhook destinations for the application
+   * @param overrides Optional request overrides to apply
    * @return The list of webhook destinations
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun list(): ListResponse<Webhook> {
+  @JvmOverloads
+  fun list(overrides: RequestOverrides? = null): ListResponse<Webhook> {
     val path = "v3/webhooks"
-    return listResource(path)
+    return listResource(path, overrides = overrides)
   }
 
   /**
    * Return a webhook destination
    * @param webhookId The id of the webhook destination to retrieve.
+   * @param overrides Optional request overrides to apply
    * @return The webhook destination
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun find(webhookId: String): Response<Webhook> {
+  @JvmOverloads
+  fun find(webhookId: String, overrides: RequestOverrides? = null): Response<Webhook> {
     val path = String.format("v3/webhooks/%s", webhookId)
-    return findResource(path)
+    return findResource(path, overrides = overrides)
   }
 
   /**
    * Create a webhook destination
    * @param requestBody The values to create the webhook destination with
+   * @param overrides Optional request overrides to apply
    * @return The created webhook destination
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun create(requestBody: CreateWebhookRequest): Response<WebhookWithSecret> {
+  @JvmOverloads
+  fun create(requestBody: CreateWebhookRequest, overrides: RequestOverrides? = null): Response<WebhookWithSecret> {
     val path = "v3/webhooks"
     val adapter = JsonHelper.moshi().adapter(CreateWebhookRequest::class.java)
     val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return client.executePost(path, responseType, serializedRequestBody)
+    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Update a webhook destination
    * @param webhookId The id of the webhook destination to update.
    * @param requestBody The values to update the webhook destination with
+   * @param overrides Optional request overrides to apply
    * @return The updated webhook destination
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun update(webhookId: String, requestBody: UpdateWebhookRequest): Response<Webhook> {
+  @JvmOverloads
+  fun update(webhookId: String, requestBody: UpdateWebhookRequest, overrides: RequestOverrides? = null): Response<Webhook> {
     val path = String.format("v3/webhooks/%s", webhookId)
     val adapter = JsonHelper.moshi().adapter(UpdateWebhookRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody)
+    return updateResource(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
    * Delete a webhook destination
    * @param webhookId The id of the webhook destination to delete.
+   * @param overrides Optional request overrides to apply
    * @return The deleted webhook response
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
-  fun destroy(webhookId: String): WebhookDeleteResponse {
+  @JvmOverloads
+  fun destroy(webhookId: String, overrides: RequestOverrides? = null): WebhookDeleteResponse {
     val path = String.format("v3/webhooks/%s", webhookId)
-    return client.executeDelete(path, WebhookDeleteResponse::class.java)
+    return client.executeDelete(path, WebhookDeleteResponse::class.java, overrides = overrides)
   }
 
   /**
    * Update the webhook secret value for a destination
+   * @param webhookId The id of the webhook destination to update the secret for.
+   * @param overrides Optional request overrides to apply
    * @returns The updated webhook destination
    */
-  fun rotateSecret(webhookId: String): Response<WebhookWithSecret> {
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  @JvmOverloads
+  fun rotateSecret(webhookId: String, overrides: RequestOverrides? = null): Response<WebhookWithSecret> {
     val path = String.format("v3/webhooks/rotate-secret/%s", webhookId)
     val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
-    return client.executePost(path, responseType)
+    return client.executePost(path, responseType, overrides = overrides)
   }
 
   /**
    * Get the current list of IP addresses that Nylas sends webhooks from
+   * @param overrides Optional request overrides to apply
    * @returns The list of IP addresses that Nylas sends webhooks from
    */
-  fun ipAddresses(): Response<WebhookIpAddressesResponse> {
+  @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
+  @JvmOverloads
+  fun ipAddresses(overrides: RequestOverrides? = null): Response<WebhookIpAddressesResponse> {
     val path = "v3/webhooks/ip-addresses"
     val responseType = Types.newParameterizedType(Response::class.java, WebhookIpAddressesResponse::class.java)
-    return client.executeGet(path, responseType)
+    return client.executeGet(path, responseType, overrides = overrides)
   }
 
   /**

--- a/src/test/kotlin/com/nylas/resources/ApplicationsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/ApplicationsTests.kt
@@ -136,10 +136,12 @@ class ApplicationsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<ApplicationDetails>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/applications", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/AttachmentsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/AttachmentsTests.kt
@@ -12,10 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import java.lang.reflect.Type
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -94,10 +91,12 @@ class AttachmentsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindAttachmentQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Attachment>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/attachments/$attachmentId", pathCaptor.firstValue)
@@ -110,9 +109,11 @@ class AttachmentsTests {
 
       val pathCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).downloadResponse(
         pathCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/attachments/$attachmentId/download", pathCaptor.firstValue)
@@ -122,15 +123,17 @@ class AttachmentsTests {
     fun `downloadBytes makes a GET request to the correct path`() {
       val byteArray = byteArrayOf(0b00000100, 0b00000010, 0b00000011)
       whenever(mockResponseBody.bytes()).thenReturn(byteArray)
-      whenever(mockNylasClient.downloadResponse(any(), any())).thenReturn(mockResponseBody)
+      whenever(mockNylasClient.downloadResponse(any(), any(), overrides = eq(null))).thenReturn(mockResponseBody)
 
       val bytes = attachments.downloadBytes(grantId, attachmentId, queryParams)
 
       val pathCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).downloadResponse(
         pathCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/attachments/$attachmentId/download", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/AuthTests.kt
+++ b/src/test/kotlin/com/nylas/resources/AuthTests.kt
@@ -120,11 +120,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/token", pathCaptor.firstValue)
@@ -159,11 +161,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/token", pathCaptor.firstValue)
@@ -190,11 +194,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/token", pathCaptor.firstValue)
@@ -227,11 +233,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/token", pathCaptor.firstValue)
@@ -259,11 +267,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/custom", pathCaptor.firstValue)
@@ -284,11 +294,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ProviderDetectParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/providers/detect", pathCaptor.firstValue)
@@ -306,11 +318,13 @@ class AuthTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ProviderDetectParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<CodeExchangeResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/revoke?token=user-token", pathCaptor.firstValue)
@@ -327,10 +341,12 @@ class AuthTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<TokenInfoRequest>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<TokenInfoResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/tokeninfo", pathCaptor.firstValue)
@@ -347,10 +363,12 @@ class AuthTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<TokenInfoRequest>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<TokenInfoResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connect/tokeninfo", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/CalendarsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/CalendarsTest.kt
@@ -97,10 +97,12 @@ class CalendarsTest {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/calendars", pathCaptor.firstValue)
@@ -115,10 +117,12 @@ class CalendarsTest {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/calendars/$calendarId", pathCaptor.firstValue)
@@ -141,11 +145,13 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/calendars", pathCaptor.firstValue)
@@ -172,11 +178,13 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/calendars/$calendarId", pathCaptor.firstValue)
@@ -192,10 +200,12 @@ class CalendarsTest {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/calendars/$calendarId", pathCaptor.firstValue)
@@ -263,11 +273,13 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/calendars/availability", pathCaptor.firstValue)
@@ -290,11 +302,13 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       val listOfFreeBusy = Types.newParameterizedType(List::class.java, GetFreeBusyResponse::class.java)

--- a/src/test/kotlin/com/nylas/resources/ConnectorsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/ConnectorsTests.kt
@@ -90,10 +90,12 @@ class ConnectorsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Connector>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors", pathCaptor.firstValue)
@@ -106,10 +108,12 @@ class ConnectorsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Connector>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google", pathCaptor.firstValue)
@@ -136,11 +140,13 @@ class ConnectorsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Connector>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors", pathCaptor.firstValue)
@@ -166,11 +172,13 @@ class ConnectorsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePatch<Response<Connector>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google", pathCaptor.firstValue)
@@ -184,10 +192,12 @@ class ConnectorsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/imap", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/ContactsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/ContactsTests.kt
@@ -204,10 +204,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactsQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts", pathCaptor.firstValue)
@@ -222,10 +224,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactsQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts", pathCaptor.firstValue)
@@ -245,10 +249,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindContactQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts/$contactId", pathCaptor.firstValue)
@@ -265,10 +271,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindContactQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts/$contactId", pathCaptor.firstValue)
@@ -337,11 +345,13 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts", pathCaptor.firstValue)
@@ -411,11 +421,13 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts/$contactId", pathCaptor.firstValue)
@@ -431,10 +443,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts/$contactId", pathCaptor.firstValue)
@@ -467,10 +481,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactGroupsQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<ContactGroup>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts/groups", pathCaptor.firstValue)
@@ -487,10 +503,12 @@ class ContactsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactGroupsQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<ContactGroup>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/contacts/groups", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/CredentialsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/CredentialsTests.kt
@@ -86,10 +86,12 @@ class CredentialsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google/creds", pathCaptor.firstValue)
@@ -104,10 +106,12 @@ class CredentialsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google/creds", pathCaptor.firstValue)
@@ -124,10 +128,12 @@ class CredentialsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google/creds/abc-123", pathCaptor.firstValue)
@@ -152,11 +158,13 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google/creds", pathCaptor.firstValue)
@@ -183,11 +191,13 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePatch<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/google/creds/abc-123", pathCaptor.firstValue)
@@ -203,10 +213,12 @@ class CredentialsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/connectors/imap/creds/abc-123", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/DraftsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DraftsTests.kt
@@ -164,10 +164,12 @@ class DraftsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListDraftsQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts", pathCaptor.firstValue)
@@ -182,10 +184,12 @@ class DraftsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListDraftsQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts", pathCaptor.firstValue)
@@ -201,10 +205,12 @@ class DraftsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)
@@ -232,11 +238,13 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts", pathCaptor.firstValue)
@@ -275,11 +283,13 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts", pathCaptor.firstValue)
@@ -319,12 +329,14 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeFormRequest<Response<Draft>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts", pathCaptor.firstValue)
@@ -359,11 +371,13 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)
@@ -399,11 +413,13 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)
@@ -440,12 +456,14 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeFormRequest<Response<Draft>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)
@@ -471,10 +489,12 @@ class DraftsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)
@@ -507,11 +527,13 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -183,10 +183,12 @@ class EventsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/events", pathCaptor.firstValue)
@@ -206,10 +208,12 @@ class EventsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/events/$eventId", pathCaptor.firstValue)
@@ -243,11 +247,13 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<CreateEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/events", pathCaptor.firstValue)
@@ -275,11 +281,13 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<UpdateEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/events/$eventId", pathCaptor.firstValue)
@@ -300,10 +308,12 @@ class EventsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<DestroyEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/events/$eventId", pathCaptor.firstValue)
@@ -342,11 +352,13 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<SendRsvpQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/events/$eventId/send-rsvp", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/FoldersTests.kt
+++ b/src/test/kotlin/com/nylas/resources/FoldersTests.kt
@@ -97,10 +97,12 @@ class FoldersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/folders", pathCaptor.firstValue)
@@ -117,10 +119,12 @@ class FoldersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/folders/$folderId", pathCaptor.firstValue)
@@ -144,11 +148,13 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/folders", pathCaptor.firstValue)
@@ -174,11 +180,13 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/folders/$folderId", pathCaptor.firstValue)
@@ -196,10 +204,12 @@ class FoldersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/folders/$folderId", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/GrantsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/GrantsTests.kt
@@ -99,10 +99,12 @@ class GrantsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Grant>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants", pathCaptor.firstValue)
@@ -122,10 +124,12 @@ class GrantsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Grant>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants", pathCaptor.firstValue)
@@ -142,10 +146,12 @@ class GrantsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Grant>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId", pathCaptor.firstValue)
@@ -174,11 +180,13 @@ class GrantsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePatch<Response<Grant>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId", pathCaptor.firstValue)
@@ -196,10 +204,12 @@ class GrantsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/MessagesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/MessagesTests.kt
@@ -169,10 +169,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages", pathCaptor.firstValue)
@@ -187,10 +189,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages", pathCaptor.firstValue)
@@ -207,10 +211,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/$messageId", pathCaptor.firstValue)
@@ -235,11 +241,13 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/$messageId", pathCaptor.firstValue)
@@ -257,10 +265,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/$messageId", pathCaptor.firstValue)
@@ -289,10 +299,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/schedules", pathCaptor.firstValue)
@@ -309,10 +321,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/schedules/$scheduledMessageId", pathCaptor.firstValue)
@@ -329,10 +343,12 @@ class MessagesTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/schedules/$scheduledMessageId", pathCaptor.firstValue)
@@ -376,11 +392,13 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/send", pathCaptor.firstValue)
@@ -420,11 +438,13 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/send", pathCaptor.firstValue)
@@ -465,12 +485,14 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeFormRequest<Response<Message>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/send", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/RedirectUriTests.kt
+++ b/src/test/kotlin/com/nylas/resources/RedirectUriTests.kt
@@ -93,10 +93,12 @@ class RedirectUriTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/applications/redirect-uris", pathCaptor.firstValue)
@@ -111,10 +113,12 @@ class RedirectUriTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/applications/redirect-uris/$redirectUriId", pathCaptor.firstValue)
@@ -142,11 +146,13 @@ class RedirectUriTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/applications/redirect-uris", pathCaptor.firstValue)
@@ -176,11 +182,13 @@ class RedirectUriTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePatch<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/applications/redirect-uris/$redirectUriId", pathCaptor.firstValue)
@@ -196,10 +204,12 @@ class RedirectUriTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/applications/redirect-uris/$redirectUriId", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/SmartComposeTests.kt
+++ b/src/test/kotlin/com/nylas/resources/SmartComposeTests.kt
@@ -85,11 +85,13 @@ class SmartComposeTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<CreateEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/smart-compose", pathCaptor.firstValue)
@@ -112,11 +114,13 @@ class SmartComposeTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<CreateEventQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/messages/$messageId/smart-compose", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/ThreadsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/ThreadsTests.kt
@@ -210,10 +210,12 @@ class ThreadsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/threads", pathCaptor.firstValue)
@@ -228,10 +230,12 @@ class ThreadsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/threads", pathCaptor.firstValue)
@@ -248,10 +252,12 @@ class ThreadsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/threads/$threadId", pathCaptor.firstValue)
@@ -275,11 +281,13 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/threads/$threadId", pathCaptor.firstValue)
@@ -297,10 +305,12 @@ class ThreadsTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/grants/$grantId/threads/$threadId", pathCaptor.firstValue)

--- a/src/test/kotlin/com/nylas/resources/WebhooksTests.kt
+++ b/src/test/kotlin/com/nylas/resources/WebhooksTests.kt
@@ -97,10 +97,12 @@ class WebhooksTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks", pathCaptor.firstValue)
@@ -116,10 +118,12 @@ class WebhooksTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks/$webhookId", pathCaptor.firstValue)
@@ -143,11 +147,13 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks", pathCaptor.firstValue)
@@ -173,11 +179,13 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePut<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks/$webhookId", pathCaptor.firstValue)
@@ -195,10 +203,12 @@ class WebhooksTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeDelete<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks/$webhookId", pathCaptor.firstValue)
@@ -228,11 +238,13 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executePost<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks/rotate-secret/$webhookId", pathCaptor.firstValue)
@@ -247,10 +259,12 @@ class WebhooksTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
       verify(mockNylasClient).executeGet<ListResponse<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
       )
 
       assertEquals("v3/webhooks/ip-addresses", pathCaptor.firstValue)


### PR DESCRIPTION
# Description
This PR adds support for adding a new `RequestOverride` object which can be built with fields that can override:
* API URI
* API Key
* Timeout
* and, adding additional headers

for outgoing requests.

# Usage
For all methods that call the Nylas API, there is now an additional `overrides: RequestOverrides?` field that takes in the built object and will override the specific outgoing call with whatever non-null values are present. This can also be used to add additional headers to outgoing calls. Here's an example:

```kotlin
package com.nylas

import com.nylas.models.RequestOverrides

object Main {
  @Throws(Exception::class)
  @JvmStatic
  fun main(args: Array<String>) {
    val nylas = NylasClient("API_KEY")
    
    val override = RequestOverrides(
      apiKey = "SECONDARY_API_KEY",
      apiUri = "https://random.api.nylas.com",
      timeout = 360,
      headers = mapOf("X-Header" to "value"),
    )
    
    val calendars = nylas.calendars().list("example@foo.com", overrides = override)
  }
}
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.