### PR TITLE
Add provider field to token exchange response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [2.2.1] - Released 2024-03-05
 
+### Added
+* Added support for `provider` field in code exchange response
+
 ### Changed
 * Improved message sending and draft create/update performance
 * Change default timeout to match API (90 seconds)

--- a/src/main/kotlin/com/nylas/models/CodeExchangeResponse.kt
+++ b/src/main/kotlin/com/nylas/models/CodeExchangeResponse.kt
@@ -32,6 +32,11 @@ data class CodeExchangeResponse(
   @Json(name = "email")
   val email: String? = null,
   /**
+   * The provider that the code was exchanged with.
+   */
+  @Json(name = "provider")
+  val provider: AuthProvider? = null,
+  /**
    * Only returned if the code was requested using [AccessType.OFFLINE][com.nylas.models.AccessType.OFFLINE].
    */
   @Json(name = "refresh_token")


### PR DESCRIPTION
# Description
This PR adds the `provider` field to the `CodeExchangeResponse` model.

# JIRA Link
https://nylas.atlassian.net/browse/TW-2865

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.