### PR TITLE
Fixed issue where attachments < 3mb were not being encoded correctly

### DIFF
--- a/src/main/kotlin/com/nylas/models/CreateAttachmentRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateAttachmentRequest.kt
@@ -20,7 +20,7 @@ class CreateAttachmentRequest(
   /**
    * The content of the attachment.
    */
-  @Transient
+  @Json(name = "content")
   val content: InputStream,
   /**
    * The size of the attachment in bytes.

--- a/src/main/kotlin/com/nylas/models/CreateDraftRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateDraftRequest.kt
@@ -29,7 +29,7 @@ data class CreateDraftRequest(
   /**
    * An array of files to attach to the message.
    */
-  @Transient
+  @Json(name = "attachments")
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
    * The message subject.

--- a/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
+++ b/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
@@ -29,7 +29,7 @@ data class SendMessageRequest(
   /**
    * An array of files to attach to the message.
    */
-  @Transient
+  @Json(name = "attachments")
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
    * The message subject.

--- a/src/main/kotlin/com/nylas/models/UpdateDraftRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateDraftRequest.kt
@@ -29,7 +29,7 @@ data class UpdateDraftRequest(
   /**
    * An array of files to attach to the message.
    */
-  @Transient
+  @Json(name = "attachments")
   override val attachments: List<CreateAttachmentRequest>? = null,
   /**
    * The message subject.

--- a/src/main/kotlin/com/nylas/util/CreateAttachmentRequestAdapter.kt
+++ b/src/main/kotlin/com/nylas/util/CreateAttachmentRequestAdapter.kt
@@ -1,0 +1,40 @@
+package com.nylas.util
+
+import com.nylas.models.CreateAttachmentRequest
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+
+/**
+ * This class is used to serialize and deserialize the CreateAttachmentRequest class.
+ * @suppress Not for public use.
+ */
+class CreateAttachmentRequestAdapter {
+  @ToJson
+  @Throws(UnsupportedOperationException::class)
+  fun toJson(writer: JsonWriter, value: CreateAttachmentRequest?) {
+    writer.beginObject()
+    writer.name("filename").value(value?.filename)
+    writer.name("content_type").value(value?.contentType)
+    writer.name("size").value(value?.size)
+    value?.isInline?.let { writer.name("is_inline").value(it) }
+    value?.contentId?.let { writer.name("content_id").value(it) }
+    value?.contentDisposition?.let { writer.name("content_disposition").value(it) }
+
+    // Encode the file stream to base64
+    value?.content?.let {
+      val base64Content = it.use { stream ->
+        FileUtils.encodeStreamToBase64(stream)
+      }
+      writer.name("content").value(base64Content)
+    }
+
+    writer.endObject()
+  }
+
+  @FromJson
+  @Throws(UnsupportedOperationException::class)
+  fun fromJson(reader: com.squareup.moshi.JsonReader): CreateAttachmentRequest? {
+    throw UnsupportedOperationException("Deserialization not supported")
+  }
+}

--- a/src/main/kotlin/com/nylas/util/FileUtils.kt
+++ b/src/main/kotlin/com/nylas/util/FileUtils.kt
@@ -7,10 +7,12 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.BufferedSink
 import okio.source
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.*
 
 class FileUtils {
   companion object {
@@ -89,6 +91,17 @@ class FileUtils {
       }
 
       return multipartBuilder.build()
+    }
+
+    /**
+     * Encode an [InputStream] to a base64 string.
+     * @param inputStream The input stream to encode.
+     * @return The base64 encoded string.
+     */
+    fun encodeStreamToBase64(inputStream: InputStream): String {
+      val buffer = ByteArrayOutputStream()
+      inputStream.copyTo(buffer)
+      return Base64.getEncoder().encodeToString(buffer.toByteArray())
     }
   }
 }

--- a/src/main/kotlin/com/nylas/util/JsonHelper.kt
+++ b/src/main/kotlin/com/nylas/util/JsonHelper.kt
@@ -35,6 +35,7 @@ class JsonHelper {
       .add(IMessageAdapter())
       .add(UpdateConnectorAdapter())
       .add(CredentialDataAdapter())
+      .add(CreateAttachmentRequestAdapter())
       .add(MicrosoftAdminConsentCredentialDataAdapter())
       .add(GoogleServiceAccountCredentialDataAdapter())
       .add(ConnectorOverrideCredentialDataAdapter())

--- a/src/test/kotlin/com/nylas/resources/DraftsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DraftsTests.kt
@@ -249,6 +249,7 @@ class DraftsTests {
     fun `creating a draft with small attachment calls requests with the correct params`() {
       val adapter = JsonHelper.moshi().adapter(CreateDraftRequest::class.java)
       val testInputStream = ByteArrayInputStream("test data".toByteArray())
+      val testInputStreamCopy = ByteArrayInputStream("test data".toByteArray())
       val createDraftRequest =
         CreateDraftRequest(
           body = "Hello, I just sent a message using Nylas!",
@@ -268,6 +269,16 @@ class DraftsTests {
             ),
           ),
         )
+      val expectedRequest = createDraftRequest.copy(
+        attachments = listOf(
+          CreateAttachmentRequest(
+            content = testInputStreamCopy,
+            contentType = "text/plain",
+            filename = "attachment.txt",
+            size = 100,
+          ),
+        ),
+      )
 
       drafts.create(grantId, createDraftRequest)
 
@@ -284,7 +295,7 @@ class DraftsTests {
 
       assertEquals("v3/grants/$grantId/drafts", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Draft::class.java), typeCaptor.firstValue)
-      assertEquals(adapter.toJson(createDraftRequest), requestBodyCaptor.firstValue)
+      assertEquals(adapter.toJson(expectedRequest), requestBodyCaptor.firstValue)
       assertNull(queryParamCaptor.firstValue)
     }
 
@@ -311,6 +322,7 @@ class DraftsTests {
             ),
           ),
         )
+      val attachmentLessRequest = createDraftRequest.copy(attachments = null)
 
       drafts.create(grantId, createDraftRequest)
 
@@ -337,7 +349,7 @@ class DraftsTests {
       val fileBuffer = Buffer()
       multipart.part(0).body().writeTo(buffer)
       multipart.part(1).body().writeTo(fileBuffer)
-      assertEquals(adapter.toJson(createDraftRequest), buffer.readUtf8())
+      assertEquals(adapter.toJson(attachmentLessRequest), buffer.readUtf8())
       assertEquals("test data", fileBuffer.readUtf8())
     }
 
@@ -377,6 +389,7 @@ class DraftsTests {
       val draftId = "draft-123"
       val adapter = JsonHelper.moshi().adapter(UpdateDraftRequest::class.java)
       val testInputStream = ByteArrayInputStream("test data".toByteArray())
+      val testInputStreamCopy = ByteArrayInputStream("test data".toByteArray())
       val updateDraftRequest =
         UpdateDraftRequest(
           body = "Hello, I just sent a message using Nylas!",
@@ -392,6 +405,16 @@ class DraftsTests {
             ),
           ),
         )
+      val expectedRequest = updateDraftRequest.copy(
+        attachments = listOf(
+          CreateAttachmentRequest(
+            content = testInputStreamCopy,
+            contentType = "text/plain",
+            filename = "attachment.txt",
+            size = 100,
+          ),
+        ),
+      )
 
       drafts.update(grantId, draftId, updateDraftRequest)
 
@@ -408,7 +431,7 @@ class DraftsTests {
 
       assertEquals("v3/grants/$grantId/drafts/$draftId", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Draft::class.java), typeCaptor.firstValue)
-      assertEquals(adapter.toJson(updateDraftRequest), requestBodyCaptor.firstValue)
+      assertEquals(adapter.toJson(expectedRequest), requestBodyCaptor.firstValue)
       assertNull(queryParamCaptor.firstValue)
     }
 
@@ -432,6 +455,7 @@ class DraftsTests {
             ),
           ),
         )
+      val attachmentLessRequest = updateDraftRequest.copy(attachments = null)
 
       drafts.update(grantId, draftId, updateDraftRequest)
 
@@ -458,7 +482,7 @@ class DraftsTests {
       val fileBuffer = Buffer()
       multipart.part(0).body().writeTo(buffer)
       multipart.part(1).body().writeTo(fileBuffer)
-      assertEquals(adapter.toJson(updateDraftRequest), buffer.readUtf8())
+      assertEquals(adapter.toJson(attachmentLessRequest), buffer.readUtf8())
       assertEquals("test data", fileBuffer.readUtf8())
     }
 


### PR DESCRIPTION
# Description
This PR fixes an issue where we were not encoding attachments less than 3mb properly. 

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.