### PR TITLE
Fix when type for date

### DIFF
--- a/src/main/kotlin/com/nylas/models/When.kt
+++ b/src/main/kotlin/com/nylas/models/When.kt
@@ -29,7 +29,7 @@ sealed class When {
     val date: String,
   ) : When() {
     @Json(name = "object")
-    override val obj: WhenType = WhenType.DATESPAN
+    override val obj: WhenType = WhenType.DATE
   }
 
   /**

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -156,6 +156,56 @@ class EventsTests {
       assertEquals("America/New_York", whenTimespan.startTimezone)
       assertEquals("America/New_York", whenTimespan.endTimezone)
     }
+
+    @Test
+    fun `Event serializes when with date type properly`() {
+      val adapter = JsonHelper.moshi().adapter(Event::class.java)
+      val jsonBuffer =
+        Buffer().writeUtf8(
+          """
+          {
+            "busy": true,
+            "calendar_id": "7d93zl2palhxqdy6e5qinsakt",
+            "created_at": 1661874192,
+            "description": "Description of my new calendar",
+            "hide_participants": false,
+            "grant_id": "41009df5-bf11-4c97-aa18-b285b5f2e386",
+            "html_link": "https://www.google.com/calendar/event?eid=bTMzcGJrNW4yYjk4bjk3OWE4Ef3feD2VuM29fMjAyMjA2MjdUMjIwMDAwWiBoYWxsYUBueWxhcy5jb20",
+            "id": "5d3qmne77v32r8l4phyuksl2x",
+            "location": "Roller Rink",
+            "object": "event",
+            "organizer": {
+              "email": "organizer@example.com",
+              "name": ""
+            },
+            "read_only": false,
+            "reminders": {
+              "use_default": false,
+              "overrides": [
+                {
+                  "reminder_minutes": 10,
+                  "reminder_method": "email"
+                }
+              ]
+            },
+            "status": "confirmed",
+            "title": "Birthday Party",
+            "updated_at": 1661874192,
+            "visibility": "private",
+            "when": {
+              "date": "2024-06-18",
+              "object": "date"
+            }
+          }
+          """.trimIndent(),
+        )
+
+      val event = adapter.fromJson(jsonBuffer)!!
+      assertIs<Event>(event)
+      assertIs<When.Date>(event.getWhen())
+      val whenDate = event.getWhen() as When.Date
+      assertEquals("2024-06-18", whenDate.date)
+    }
   }
 
   @Nested


### PR DESCRIPTION
Update When Date class to use `WhenType` of `DATE` instead of `DATESPAN`.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.