### PR TITLE
Add ews to AuthProvider enum

### DIFF
--- a/src/main/kotlin/com/nylas/models/AuthProvider.kt
+++ b/src/main/kotlin/com/nylas/models/AuthProvider.kt
@@ -20,4 +20,7 @@ enum class AuthProvider(val value: String) {
 
   @Json(name = "icloud")
   ICLOUD("icloud"),
+
+  @Json(name = "ews")
+  EWS("ews"),
 }


### PR DESCRIPTION
Add EWS to list of supported providers.  This value is used for on-prem exchange grants in v3.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.