### PR TITLE
Adding `master_event_id` as a property to the Event data class

### DIFF
--- a/src/main/kotlin/com/nylas/models/Event.kt
+++ b/src/main/kotlin/com/nylas/models/Event.kt
@@ -94,6 +94,11 @@ data class Event(
   @Json(name = "organizer")
   val organizer: EmailName? = null,
   /**
+   * Organizer of the event.
+   */
+  @Json(name = "master_event_id")
+  val masterEventId: String? = null,
+  /**
    * A list of RRULE and EXDATE strings.
    * @see <a href="https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.5">RFC-5545</a>
    */


### PR DESCRIPTION
# Description

Adding getter/setter support for `master_even_id`

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.