### PR TITLE
v2.4.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Nylas Java SDK Changelog
 
+### [2.4.1] - Released 2024-07-26
+
+### Changed
+* Added missing `masterEventId` field in `Event` model
+* Added missing `EWS` provider in `Provider` enum
+* Fixed issue where the revoke OAuth token function was not working correctly
+
 ### [2.4.0] - Released 2024-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,7 +475,8 @@ This second release aims toward API stability so that we can get to v1.0.0.
 
 Initial preview release
 
-[Unreleased]: https://github.com/nylas/nylas-java/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/nylas/nylas-java/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/nylas/nylas-java/releases/tag/v2.4.1
 [2.4.0]: https://github.com/nylas/nylas-java/releases/tag/v2.4.0
 [2.3.2]: https://github.com/nylas/nylas-java/releases/tag/v2.3.2
 [2.3.1]: https://github.com/nylas/nylas-java/releases/tag/v2.3.1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have a question about the Nylas Communications Platform, [contact Nylas S
 If you're using Gradle, add the following to the dependencies section of `build.gradle`:
 
 ```groovy
-implementation("com.nylas.sdk:nylas:2.4.0")
+implementation("com.nylas.sdk:nylas:2.4.1")
 ```
 
 ### Build from source
@@ -42,7 +42,7 @@ git clone https://github.com/nylas/nylas-java.git && cd nylas-java
 ./gradlew build uberJar
 ```
 
-This creates a new jar file in `build/libs/nylas-java-sdk-2.4.0-uber.jar`.
+This creates a new jar file in `build/libs/nylas-java-sdk-2.4.1-uber.jar`.
 
 See the Gradle documentation on [Building Libraries](https://guides.gradle.org/building-java-libraries/)
 or the [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html) for more information.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.4.0
+version=2.4.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Changelog
* Added missing `masterEventId` field in `Event` model
* Added missing `EWS` provider in `Provider` enum
* Fixed issue where the revoke OAuth token function was not working correctly

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.