### PR TITLE
Improve error handling for attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+### Unreleased
+
+### Added
+* Added new error class `NylasSdkRemoteClosedError` for when the remote connection is closed
+
 ### [2.4.1] - Released 2024-07-26
 
 ### Changed

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -368,6 +368,8 @@ class NylasClient(
       throw NylasSdkTimeoutError(finalUrl.toString(), httpClient.callTimeoutMillis())
     } catch (e: SocketException) {
       throw NylasSdkRemoteClosedError(finalUrl.toString(), e.message ?: "Unknown error")
+    } catch (e: AbstractNylasApiError) {
+      throw e
     } catch (e: Exception) {
       throw NylasApiError(
         type = "unknown",

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -12,6 +12,7 @@ import okhttp3.Response
 import java.io.IOException
 import java.lang.Exception
 import java.lang.reflect.Type
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 
@@ -76,112 +77,84 @@ class NylasClient(
    * Access the Applications API
    * @return The Applications API
    */
-  fun applications(): Applications {
-    return Applications(this)
-  }
+  fun applications(): Applications = Applications(this)
 
   /**
    * Access the Attachments API
    * @return The Attachments API
    */
-  fun attachments(): Attachments {
-    return Attachments(this)
-  }
+  fun attachments(): Attachments = Attachments(this)
 
   /**
    * Access the Auth API
    * @return The Auth API
    */
-  fun auth(): Auth {
-    return Auth(this)
-  }
+  fun auth(): Auth = Auth(this)
 
   /**
    * Access the Calendars API
    * @return The Calendars API
    */
-  fun calendars(): Calendars {
-    return Calendars(this)
-  }
+  fun calendars(): Calendars = Calendars(this)
 
   /**
    * Access the Connectors API
    * @return The Connectors API
    */
-  fun connectors(): Connectors {
-    return Connectors(this)
-  }
+  fun connectors(): Connectors = Connectors(this)
 
   /**
    * Access the Drafts API
    * @return The Drafts API
    */
-  fun drafts(): Drafts {
-    return Drafts(this)
-  }
+  fun drafts(): Drafts = Drafts(this)
 
   /**
    * Access the Events API
    * @return The Events API
    */
-  fun events(): Events {
-    return Events(this)
-  }
+  fun events(): Events = Events(this)
 
   /**
    * Access the Folders API
    * @return The Folders API
    */
-  fun folders(): Folders {
-    return Folders(this)
-  }
+  fun folders(): Folders = Folders(this)
 
   /**
    * Access the Grants API
    * @return The Grants API
    */
-  fun grants(): Grants {
-    return Grants(this)
-  }
+  fun grants(): Grants = Grants(this)
 
   /**
    * Access the Messages API
    * @return The Messages API
    */
-  fun messages(): Messages {
-    return Messages(this)
-  }
+  fun messages(): Messages = Messages(this)
 
   /**
    * Access the Threads API
    * @return The Threads API
    */
-  fun threads(): Threads {
-    return Threads(this)
-  }
+  fun threads(): Threads = Threads(this)
 
   /**
    * Access the Webhooks API
    * @return The Webhooks API
    */
-  fun webhooks(): Webhooks {
-    return Webhooks(this)
-  }
+  fun webhooks(): Webhooks = Webhooks(this)
 
   /**
    * Access the Contacts API
    * @return The Contacts API
    */
-  fun contacts(): Contacts {
-    return Contacts(this)
-  }
+  fun contacts(): Contacts = Contacts(this)
 
   /**
    * Get a URL builder instance for the Nylas API.
    */
-  fun newUrlBuilder(): HttpUrl.Builder {
-    return apiUri.newBuilder()
-  }
+  fun newUrlBuilder(): HttpUrl.Builder = apiUri.newBuilder()
 
   /**
    * Execute a GET request to the Nylas API.
@@ -550,13 +523,11 @@ class NylasClient(
    */
   companion object {
     val DEFAULT_BASE_URL = Region.US.nylasApiUrl
-    private fun defaultHttpClient(): OkHttpClient.Builder {
-      return OkHttpClient.Builder()
-        .connectTimeout(90, TimeUnit.SECONDS)
-        .readTimeout(90, TimeUnit.SECONDS)
-        .writeTimeout(90, TimeUnit.SECONDS)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .addNetworkInterceptor(HttpLoggingInterceptor())
-    }
+    private fun defaultHttpClient(): OkHttpClient.Builder = OkHttpClient.Builder()
+      .connectTimeout(90, TimeUnit.SECONDS)
+      .readTimeout(90, TimeUnit.SECONDS)
+      .writeTimeout(90, TimeUnit.SECONDS)
+      .protocols(listOf(Protocol.HTTP_1_1))
+      .addNetworkInterceptor(HttpLoggingInterceptor())
   }
 }

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -393,6 +393,14 @@ class NylasClient(
       return response.body() ?: throw Exception("Unexpected null response body")
     } catch (e: SocketTimeoutException) {
       throw NylasSdkTimeoutError(finalUrl.toString(), httpClient.callTimeoutMillis())
+    } catch (e: SocketException) {
+      throw NylasSdkRemoteClosedError(finalUrl.toString(), e.message ?: "Unknown error")
+    } catch (e: Exception) {
+      throw NylasApiError(
+        type = "unknown",
+        message = "Unknown error occurred: ${e.message}",
+        statusCode = 0,
+      )
     }
   }
 

--- a/src/main/kotlin/com/nylas/models/NylasSdkRemoteClosedError.kt
+++ b/src/main/kotlin/com/nylas/models/NylasSdkRemoteClosedError.kt
@@ -1,0 +1,11 @@
+package com.nylas.models
+
+/**
+ * Error thrown when the Nylas API closes the connection before the Nylas SDK receives a response.
+ * @param url The URL that timed out.
+ * @param originalErrorMessage The error message from the library that closed the connection.
+ */
+class NylasSdkRemoteClosedError(
+  url: String,
+  originalErrorMessage: String,
+) : AbstractNylasSdkError("Nylas API closed the connection before the Nylas SDK received a response.")

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -309,11 +309,12 @@ class NylasClientTest {
       val urlBuilder = nylasClient.newUrlBuilder()
       whenever(mockResponse.body()).thenReturn(null)
 
-      val exception = assertFailsWith<Exception> {
+      val exception = assertFailsWith<NylasApiError> {
         nylasClient.executeRequest(urlBuilder, NylasClient.HttpMethod.GET, null, String::class.java)
       }
 
-      assertEquals("Unexpected null response body", exception.message)
+      assertEquals("Unknown error occurred: Unexpected null response body", exception.message)
+      assertEquals("unknown", exception.type)
     }
 
     // TODO::Should we handle this case?

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -1,11 +1,9 @@
 package com.nylas
 
-import com.nylas.models.IQueryParams
-import com.nylas.models.NylasApiError
-import com.nylas.models.NylasOAuthError
-import com.nylas.models.NylasSdkTimeoutError
+import com.nylas.models.*
 import com.nylas.util.JsonHelper
 import okhttp3.*
+import okhttp3.Response
 import okio.Buffer
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -18,6 +16,7 @@ import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.nio.charset.StandardCharsets
 import kotlin.test.assertFailsWith
@@ -298,6 +297,18 @@ class NylasClientTest {
       whenever(mockCall.execute()).thenThrow(SocketTimeoutException())
 
       val exception = assertFailsWith<NylasSdkTimeoutError> {
+        nylasClient.executeRequest(urlBuilder, NylasClient.HttpMethod.GET, null, String::class.java)
+      }
+
+      assertNotNull(exception)
+    }
+
+    @Test
+    fun `should handle socket exception`() {
+      val urlBuilder = nylasClient.newUrlBuilder()
+      whenever(mockCall.execute()).thenThrow(SocketException())
+
+      val exception = assertFailsWith<NylasSdkRemoteClosedError> {
         nylasClient.executeRequest(urlBuilder, NylasClient.HttpMethod.GET, null, String::class.java)
       }
 


### PR DESCRIPTION
# Description
This PR introduces a new error in the case that a user uploads a file that is too large, causing the remote connection to be closed on the API side.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.