### PR TITLE
Adding support for Accept-Encoding: gzip in HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Nylas Java SDK Changelog
 
+### Unreleased
+* Added support for `Accept-Encoding: gzip` in HTTP headers
+
 ### [2.5.0] - Released 2024-09-25
 
 ### Added

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -63,7 +63,7 @@ class NylasClient(
     ACCEPT("Accept"),
     AUTHORIZATION("Authorization"),
     CONTENT_TYPE("Content-Type"),
-    ACCEPT_ENCODING("Accept-Encoding")
+    ACCEPT_ENCODING("Accept-Encoding"),
   }
 
   init {

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -63,6 +63,7 @@ class NylasClient(
     ACCEPT("Accept"),
     AUTHORIZATION("Authorization"),
     CONTENT_TYPE("Content-Type"),
+    ACCEPT_ENCODING("Accept-Encoding")
   }
 
   init {

--- a/src/main/kotlin/com/nylas/interceptors/AddVersionHeadersInterceptor.kt
+++ b/src/main/kotlin/com/nylas/interceptors/AddVersionHeadersInterceptor.kt
@@ -13,6 +13,7 @@ class AddVersionHeadersInterceptor : Interceptor {
   override fun intercept(chain: Interceptor.Chain): Response {
     val requestBuilder = chain.request().newBuilder()
       .header("User-Agent", USER_AGENT)
+      .header("Accept-Encoding", "gzip")
     return chain.proceed(requestBuilder.build())
   }
 

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -503,6 +503,7 @@ class NylasClientTest {
       assertEquals("Accept", NylasClient.HttpHeaders.ACCEPT.headerName)
       assertEquals("Authorization", NylasClient.HttpHeaders.AUTHORIZATION.headerName)
       assertEquals("Content-Type", NylasClient.HttpHeaders.CONTENT_TYPE.headerName)
+      assertEquals("Accept-Encoding", NylasClient.HttpHeaders.ACCEPT_ENCODING.headerName)
     }
   }
 }


### PR DESCRIPTION
# Description
- Added `Accept-Encoding: gzip` header to HTTP requests.
- This change allows the client to request Gzip-compressed responses from the server, improving data transfer efficiency and reducing load times.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.