### PR TITLE
Fix the response type for listing of scheduled messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Added support for `Accept-Encoding: gzip` in HTTP headers
+* Fixed response type for returning list of scheduled messages
 
 ### [2.5.0] - Released 2024-09-25
 

--- a/src/main/kotlin/com/nylas/resources/Messages.kt
+++ b/src/main/kotlin/com/nylas/resources/Messages.kt
@@ -111,9 +111,9 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
-  fun listScheduledMessages(identifier: String, overrides: RequestOverrides? = null): Response<ScheduledMessagesList> {
+  fun listScheduledMessages(identifier: String, overrides: RequestOverrides? = null): ListResponse<ScheduledMessage> {
     val path = String.format("v3/grants/%s/messages/schedules", identifier)
-    val responseType = Types.newParameterizedType(Response::class.java, ScheduledMessagesList::class.java)
+    val responseType = Types.newParameterizedType(ListResponse::class.java, ScheduledMessage::class.java)
     return client.executeGet(path, responseType, overrides = overrides)
   }
 

--- a/src/test/kotlin/com/nylas/resources/MessagesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/MessagesTests.kt
@@ -300,7 +300,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Message>>(
+      verify(mockNylasClient).executeGet<ListResponse<ScheduledMessage>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -308,7 +308,7 @@ class MessagesTests {
       )
 
       assertEquals("v3/grants/$grantId/messages/schedules", pathCaptor.firstValue)
-      assertEquals(Types.newParameterizedType(Response::class.java, ScheduledMessagesList::class.java), typeCaptor.firstValue)
+      assertEquals(Types.newParameterizedType(ListResponse::class.java, ScheduledMessage::class.java), typeCaptor.firstValue)
       assertNull(queryParamCaptor.firstValue)
     }
 


### PR DESCRIPTION
# Description
- Change response type to ListResponse when listing scheduled messages.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.