### PR TITLE
Add skypeForConsumer as conferencing provider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Nylas Java SDK Changelog
 
+### Unreleased
+* Add support for `skypeForConsumer` as conferencing provider
+
 ### [2.5.1] - Released 2024-11-12
 * Fixed response type for returning list of scheduled messages
 

--- a/src/main/kotlin/com/nylas/models/ConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/ConferencingProvider.kt
@@ -20,4 +20,7 @@ enum class ConferencingProvider {
 
   @Json(name = "GoToMeeting")
   GOTOMEETING,
+
+  @Json(name = "skypeForConsumer")
+  SKYPE_FOR_CONSUMER,
 }


### PR DESCRIPTION
- Free Outlook accounts supports creating  skype as conferencing while creating events.
- Currently this is not listed as supported conferencing provider in JAVA sdk.
- When user fetches event and an event has skype as conferencing, the request fails due to unsupported conferencing.
- Add `skypeForConsumer` as supported conferencing provider.
- Reproduced the error locally and tested the fix locally.


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.