### PR TITLE
v2.5.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Nylas Java SDK Changelog
 
-### Unreleased
-* Add support for `skypeForConsumer` as conferencing provider
+### [2.5.2] - Released 2024-12-02
+* Added support for `skypeForConsumer` as conferencing provider
 
 ### [2.5.1] - Released 2024-11-12
 * Fixed response type for returning list of scheduled messages

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have a question about the Nylas Communications Platform, [contact Nylas S
 If you're using Gradle, add the following to the dependencies section of `build.gradle`:
 
 ```groovy
-implementation("com.nylas.sdk:nylas:2.5.1")
+implementation("com.nylas.sdk:nylas:2.5.2")
 ```
 
 ### Build from source
@@ -42,7 +42,7 @@ git clone https://github.com/nylas/nylas-java.git && cd nylas-java
 ./gradlew build uberJar
 ```
 
-This creates a new jar file in `build/libs/nylas-java-sdk-2.5.1-uber.jar`.
+This creates a new jar file in `build/libs/nylas-java-sdk-2.5.2-uber.jar`.
 
 See the Gradle documentation on [Building Libraries](https://guides.gradle.org/building-java-libraries/)
 or the [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html) for more information.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.5.1
+version=2.5.2
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
* Added support for `skypeForConsumer` as conferencing provider
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.