### PR TITLE
Fixed issue where reminders were not being updated correctly when updating an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Added pagination support for folders
+* Fixed issue where reminders were not being updated correctly when updating an event
 
 ### [2.5.2] - Released 2024-12-02
 * Added support for `skypeForConsumer` as conferencing provider

--- a/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
@@ -496,23 +496,6 @@ data class UpdateEventRequest(
   }
 
   /**
-   * Class representing the reminders field of an event.
-   */
-  data class Reminders(
-    /**
-     * Whether to use the default reminders for the calendar.
-     * When true, uses the default reminder settings for the calendar
-     */
-    @Json(name = "use_default")
-    val useDefault: Boolean? = null,
-    /**
-     * A list of reminders for the event if useDefault is set to false.
-     */
-    @Json(name = "override")
-    val override: List<ReminderOverride>? = null,
-  )
-
-  /**
    * Builder for [UpdateEventRequest].
    */
   class Builder {


### PR DESCRIPTION
# Background
There was a typo in the UpdateEventRequest which supplied `override` instead of `overrides` for the reminders JSON object. However, this data class was also necessarily duplicated.  So I got rid of it and used the pre-existing data class.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.