### PR TITLE
Added sandbox to the Environment Enum.

### DIFF
--- a/src/main/kotlin/com/nylas/models/Environment.kt
+++ b/src/main/kotlin/com/nylas/models/Environment.kt
@@ -11,4 +11,7 @@ enum class Environment {
 
   @Json(name = "staging")
   STAGING,
+
+  @Json(name = "sandbox")
+  SANDBOX,
 }


### PR DESCRIPTION
Reason for PR:

While testing using a sandbox application, the following error was observed:

> Exception in thread "main" com.squareup.moshi.JsonDataException: Expected one of [production, staging] but was sandbox at path $.data.environment
        at com.squareup.moshi.StandardJsonAdapters$EnumJsonAdapter.fromJson(StandardJsonAdapters.java:296)
        at com.squareup.moshi.StandardJsonAdapters$EnumJsonAdapter.fromJson(StandardJsonAdapters.java:264)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
        at com.squareup.moshi.kotlin.reflect.KotlinJsonAdapter.fromJson(KotlinJsonAdapter.kt:86)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
        at com.squareup.moshi.kotlin.reflect.KotlinJsonAdapter.fromJson(KotlinJsonAdapter.kt:86)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
        at com.squareup.moshi.JsonAdapter.fromJson(JsonAdapter.java:58)
        at com.nylas.NylasClient.executeRequest(NylasClient.kt:357)
        at com.nylas.NylasClient.executeGet(NylasClient.kt:202)
        at com.nylas.NylasClient.executeGet$default(NylasClient.kt:195)
        at com.nylas.resources.Applications.getDetails(Applications.kt:31)
        at com.nylas.resources.Applications.getDetails$default(Applications.kt:28)
        at com.nylas.resources.Applications.getDetails(Applications.kt)
        at com.example.NylasTest.main(NylasTest.java:8)


This PR should correct the error and make testing easier for new users

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.