### PR TITLE
Updated GET notetaker to support new query params

### DIFF
--- a/src/main/kotlin/com/nylas/models/ListNotetakersQueryParams.kt
+++ b/src/main/kotlin/com/nylas/models/ListNotetakersQueryParams.kt
@@ -13,16 +13,16 @@ data class ListNotetakersQueryParams(
   val state: Notetaker.NotetakerState? = null,
 
   /**
-   * Filter for Notetaker bots that are scheduled to join meetings after the specified time.
+   * Filter for Notetaker bots that have join times that start at or after a specific time, in Unix timestamp format.
    */
-  @Json(name = "join_time_from")
-  val joinTimeFrom: Long? = null,
+  @Json(name = "join_time_start")
+  val joinTimeStart: Long? = null,
 
   /**
-   * Filter for Notetaker bots that are scheduled to join meetings until the specified time.
+   * Filter for Notetaker bots that have join times that end at or are before a specific time, in Unix timestamp format.
    */
-  @Json(name = "join_time_until")
-  val joinTimeUntil: Long? = null,
+  @Json(name = "join_time_end")
+  val joinTimeEnd: Long? = null,
 
   /**
    * The maximum number of objects to return.
@@ -51,18 +51,33 @@ data class ListNotetakersQueryParams(
    */
   @Json(name = "select")
   var select: String? = null,
+
+  /**
+   * Sort the data Nylas returns in ascending (asc) or descending (desc) order.
+   */
+  @Json(name = "order_direction")
+  val orderDirection: Notetaker.OrderDirection? = null,
+
+  /**
+   * Sort the data Nylas returns by the selected field.
+   * Defaults to created_at.
+   */
+  @Json(name = "order_field")
+  val orderField: Notetaker.OrderField? = null,
 ) : IQueryParams {
   /**
    * Builder for [ListNotetakersQueryParams].
    */
   class Builder {
     private var state: Notetaker.NotetakerState? = null
-    private var joinTimeFrom: Long? = null
-    private var joinTimeUntil: Long? = null
+    private var joinTimeStart: Long? = null
+    private var joinTimeEnd: Long? = null
     private var limit: Int? = null
     private var pageToken: String? = null
     private var prevPageToken: String? = null
     private var select: String? = null
+    private var orderDirection: Notetaker.OrderDirection? = null
+    private var orderField: Notetaker.OrderField? = null
 
     /**
      * Sets the state filter for Notetakers.
@@ -72,18 +87,18 @@ data class ListNotetakersQueryParams(
     fun state(state: Notetaker.NotetakerState?) = apply { this.state = state }
 
     /**
-     * Sets the join time from filter.
-     * @param joinTimeFrom Unix timestamp to filter Notetakers joining after this time.
+     * Sets the join time start filter.
+     * @param joinTimeStart Unix timestamp to filter Notetakers joining after this time.
      * @return The builder.
      */
-    fun joinTimeFrom(joinTimeFrom: Long?) = apply { this.joinTimeFrom = joinTimeFrom }
+    fun joinTimeStart(joinTimeStart: Long?) = apply { this.joinTimeStart = joinTimeStart }
 
     /**
-     * Sets the join time until filter.
-     * @param joinTimeUntil Unix timestamp to filter Notetakers joining until this time.
+     * Sets the join time end filter.
+     * @param joinTimeEnd Unix timestamp to filter Notetakers joining until this time.
      * @return The builder.
      */
-    fun joinTimeUntil(joinTimeUntil: Long?) = apply { this.joinTimeUntil = joinTimeUntil }
+    fun joinTimeEnd(joinTimeEnd: Long?) = apply { this.joinTimeEnd = joinTimeEnd }
 
     /**
      * Sets the maximum number of objects to return.
@@ -114,17 +129,33 @@ data class ListNotetakersQueryParams(
     fun select(select: String?) = apply { this.select = select }
 
     /**
+     * Sets the order direction for sorting results.
+     * @param orderDirection The direction to sort results in (asc or desc)
+     * @return The builder.
+     */
+    fun orderDirection(orderDirection: Notetaker.OrderDirection?) = apply { this.orderDirection = orderDirection }
+
+    /**
+     * Sets the field to sort results by.
+     * @param orderField The field to sort results by
+     * @return The builder.
+     */
+    fun orderField(orderField: Notetaker.OrderField?) = apply { this.orderField = orderField }
+
+    /**
      * Builds the [ListNotetakersQueryParams] object.
      * @return The [ListNotetakersQueryParams] object.
      */
     fun build() = ListNotetakersQueryParams(
       state = state,
-      joinTimeFrom = joinTimeFrom,
-      joinTimeUntil = joinTimeUntil,
+      joinTimeStart = joinTimeStart,
+      joinTimeEnd = joinTimeEnd,
       limit = limit,
       pageToken = pageToken,
       prevPageToken = prevPageToken,
       select = select,
+      orderDirection = orderDirection,
+      orderField = orderField,
     )
   }
 }

--- a/src/main/kotlin/com/nylas/models/Notetaker.kt
+++ b/src/main/kotlin/com/nylas/models/Notetaker.kt
@@ -101,6 +101,31 @@ data class Notetaker(
   }
 
   /**
+   * Enum for list order direction options
+   */
+  enum class OrderDirection {
+    @Json(name = "asc")
+    ASC,
+
+    @Json(name = "desc")
+    DESC,
+  }
+
+  /**
+   * Enum for list order field options
+   */
+  enum class OrderField {
+    @Json(name = "created_at")
+    CREATED_AT,
+
+    @Json(name = "name")
+    NAME,
+
+    @Json(name = "join_time")
+    JOIN_TIME,
+  }
+
+  /**
    * Data class for Notetaker Meeting Settings
    */
   data class MeetingSettings(

--- a/src/test/kotlin/com/nylas/resources/NotetakersTests.kt
+++ b/src/test/kotlin/com/nylas/resources/NotetakersTests.kt
@@ -157,9 +157,14 @@ class NotetakersTests {
     @Test
     fun `listing notetakers calls requests with the correct params`() {
       val queryParams = ListNotetakersQueryParams(
+        state = Notetaker.NotetakerState.SCHEDULED,
+        joinTimeStart = 1234567890,
+        joinTimeEnd = 1234567899,
         limit = 10,
         pageToken = "abc-123",
         select = "id,updated_at",
+        orderDirection = Notetaker.OrderDirection.ASC,
+        orderField = Notetaker.OrderField.NAME,
       )
 
       notetakers.list(queryParams, grantId)


### PR DESCRIPTION
# What did you do?
- [x] Renamed GET notetaker query params `join_time_from` and  `join_time_until` to `join_time_start` and `join_time_end`
- [x] Added support for  GET notetaker query params `orderDirection` and `orderBy`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.