### PR TITLE
feat: add name attribute support to Scheduler Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+### Added
+* Added support for `name` attribute in Scheduler Configuration class to allow custom naming of Scheduling Pages
+
 ### [2.8.0] - Release 2025-04-30
 * Added support for Notetaker APIs
 * Added support for Notetaker via the calendar and event APIs

--- a/src/main/kotlin/com/nylas/models/CreateConfigurationRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateConfigurationRequest.kt
@@ -22,6 +22,11 @@ data class CreateConfigurationRequest(
   @Json(name = "event_booking")
   val eventBooking: ConfigurationEventBooking,
   /**
+   * The name of the Scheduling Page. If not set, it defaults to the organizer's name.
+   */
+  @Json(name = "name")
+  val name: String? = null,
+  /**
    * Unique identifier for the Configuration object.
    */
   @Json(name = "slug")
@@ -54,9 +59,18 @@ data class CreateConfigurationRequest(
     private val eventBooking: ConfigurationEventBooking,
   ) {
     private var requiresSessionAuth: Boolean? = null
+    private var name: String? = null
     private var slug: String? = null
     private var scheduler: ConfigurationSchedulerSettings? = null
     private var appearance: Map<String, String>? = null
+
+    /**
+     * Set the name of the Scheduling Page.
+     *
+     * @param name The name of the Scheduling Page. If not set, it defaults to the organizer's name.
+     * @return The builder
+     */
+    fun name(name: String) = apply { this.name = name }
 
     /**
      * Set the unique identifier for the configuration.
@@ -99,6 +113,7 @@ data class CreateConfigurationRequest(
       participants,
       availability,
       eventBooking,
+      name,
       slug,
       requiresSessionAuth,
       scheduler,

--- a/src/main/kotlin/com/nylas/models/Scheduler.kt
+++ b/src/main/kotlin/com/nylas/models/Scheduler.kt
@@ -27,6 +27,11 @@ data class Configuration(
   @Json(name = "event_booking")
   val eventBooking: ConfigurationEventBooking,
   /**
+   * The name of the Scheduling Page. If not set, it defaults to the organizer's name.
+   */
+  @Json(name = "name")
+  val name: String? = null,
+  /**
    * Unique identifier for the Configuration object.
    */
   @Json(name = "slug")

--- a/src/main/kotlin/com/nylas/models/UpdateConfigurationRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateConfigurationRequest.kt
@@ -22,6 +22,11 @@ data class UpdateConfigurationRequest(
   @Json(name = "event_booking")
   val eventBooking: ConfigurationEventBooking? = null,
   /**
+   * The name of the Scheduling Page. If not set, it defaults to the organizer's name.
+   */
+  @Json(name = "name")
+  val name: String? = null,
+  /**
    * Unique identifier for the Configuration object.
    */
   @Json(name = "slug")
@@ -49,6 +54,7 @@ data class UpdateConfigurationRequest(
     private var participants: List<ConfigurationParticipant>? = null
     private var availability: ConfigurationAvailability? = null
     private var eventBooking: ConfigurationEventBooking? = null
+    private var name: String? = null
     private var requiresSessionAuth: Boolean? = null
     private var slug: String? = null
     private var scheduler: ConfigurationSchedulerSettings? = null
@@ -76,12 +82,12 @@ data class UpdateConfigurationRequest(
     fun eventBooking(eventBooking: ConfigurationEventBooking) = apply { this.eventBooking = eventBooking }
 
     /**
-     * Set the unique identifier for the configuration.
+     * Set the name of the Scheduling Page.
      *
-     * @param slug Unique identifier for the Configuration object.
+     * @param name The name of the Scheduling Page. If not set, it defaults to the organizer's name.
      * @return The builder
      */
-    fun slug(slug: String) = apply { this.slug = slug }
+    fun name(name: String) = apply { this.name = name }
 
     /**
      * Set if scheduling Availability and Bookings endpoints require a valid session ID.
@@ -108,6 +114,14 @@ data class UpdateConfigurationRequest(
     fun appearance(appearance: Map<String, String>) = apply { this.appearance = appearance }
 
     /**
+     * Set the unique identifier for the configuration.
+     *
+     * @param slug Unique identifier for the Configuration object.
+     * @return The builder
+     */
+    fun slug(slug: String) = apply { this.slug = slug }
+
+    /**
      * Build the [UpdateConfigurationRequest].
      *
      * @return The [UpdateConfigurationRequest]
@@ -116,6 +130,7 @@ data class UpdateConfigurationRequest(
       participants,
       availability,
       eventBooking,
+      name,
       slug,
       requiresSessionAuth,
       scheduler,


### PR DESCRIPTION
# What did you do?
- Add name field to Configuration, CreateConfigurationRequest, and UpdateConfigurationRequest models
- Add builder support for name attribute in both create and update request classes
- Add comprehensive tests for name attribute serialization and builder functionality
- Name field is optional and defaults to organizer's name when not set
- Fully backward compatible implementation

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.