### PR TITLE
fix: ListThreadsQueryParams.inFolder now correctly uses single folder ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 * Support for query parameters in `Messages.find()` method to specify fields like `include_tracking_options` and `raw_mime`
 * Added `Builder` pattern to `FindMessageQueryParams` for consistency with other query parameter classes
 
+### Fixed
+* Fixed `ListThreadsQueryParams.inFolder` parameter to properly handle single folder ID filtering as expected by the Nylas API. The API only supports filtering by a single folder ID, but the SDK was incorrectly accepting a list and only using the last item. Now the SDK uses the first item from a list if provided and includes overloaded `inFolder(String)` method in the Builder for new code. The list-based method is deprecated and will be changed to String in the next major version for backwards compatibility.
+
+### Deprecated
+* `ListThreadsQueryParams.Builder.inFolder(List<String>)` is deprecated in favor of `inFolder(String)`. The Nylas API only supports filtering by a single folder ID. In a future major version, this parameter will be changed to accept only a String.
+
 ## [2.9.0] - Release 2025-05-27
 
 ### Added

--- a/src/test/kotlin/com/nylas/models/ListThreadsQueryParamsTest.kt
+++ b/src/test/kotlin/com/nylas/models/ListThreadsQueryParamsTest.kt
@@ -1,0 +1,146 @@
+package com.nylas.models
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class ListThreadsQueryParamsTest {
+
+  @Test
+  fun `builder inFolder with string creates single item list internally`() {
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder("test-folder-id")
+      .build()
+
+    assertEquals(listOf("test-folder-id"), queryParams.inFolder)
+  }
+
+  @Test
+  fun `builder inFolder with null string creates null internally`() {
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder(null as String?)
+      .build()
+
+    assertNull(queryParams.inFolder)
+  }
+
+  @Test
+  fun `builder inFolder with list preserves list as-is`() {
+    val folderIds = listOf("folder1", "folder2", "folder3")
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder(folderIds)
+      .build()
+
+    assertEquals(folderIds, queryParams.inFolder)
+  }
+
+  @Test
+  fun `builder inFolder with empty list preserves empty list`() {
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder(emptyList<String>())
+      .build()
+
+    assertEquals(emptyList<String>(), queryParams.inFolder)
+  }
+
+  @Test
+  fun `convertToMap uses only first folder ID when multiple are provided`() {
+    val queryParams = ListThreadsQueryParams(
+      inFolder = listOf("folder1", "folder2", "folder3"),
+    )
+
+    val map = queryParams.convertToMap()
+
+    assertEquals("folder1", map["in"])
+  }
+
+  @Test
+  fun `convertToMap handles single folder ID correctly`() {
+    val queryParams = ListThreadsQueryParams(
+      inFolder = listOf("single-folder"),
+    )
+
+    val map = queryParams.convertToMap()
+
+    assertEquals("single-folder", map["in"])
+  }
+
+  @Test
+  fun `convertToMap excludes in parameter when list is empty`() {
+    val queryParams = ListThreadsQueryParams(
+      inFolder = emptyList(),
+    )
+
+    val map = queryParams.convertToMap()
+
+    assertFalse(map.containsKey("in"))
+  }
+
+  @Test
+  fun `convertToMap excludes in parameter when null`() {
+    val queryParams = ListThreadsQueryParams(
+      inFolder = null,
+    )
+
+    val map = queryParams.convertToMap()
+
+    assertFalse(map.containsKey("in"))
+  }
+
+  @Test
+  fun `convertToMap preserves other parameters while handling inFolder`() {
+    val queryParams = ListThreadsQueryParams(
+      limit = 10,
+      pageToken = "abc-123",
+      subject = "Test Subject",
+      inFolder = listOf("folder1", "folder2"),
+      unread = true,
+    )
+
+    val map = queryParams.convertToMap()
+
+    assertEquals(10.0, map["limit"])
+    assertEquals("abc-123", map["page_token"])
+    assertEquals("Test Subject", map["subject"])
+    assertEquals("folder1", map["in"]) // Only first folder ID
+    assertEquals(true, map["unread"])
+  }
+
+  @Test
+  fun `string inFolder parameter through builder creates expected query map`() {
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder("single-folder")
+      .limit(50)
+      .unread(false)
+      .build()
+
+    val map = queryParams.convertToMap()
+
+    assertEquals("single-folder", map["in"])
+    assertEquals(50.0, map["limit"])
+    assertEquals(false, map["unread"])
+  }
+
+  @Test
+  fun `overriding inFolder parameter in builder works correctly`() {
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder(listOf("folder1", "folder2")) // Set list first
+      .inFolder("final-folder") // Override with string
+      .build()
+
+    assertEquals(listOf("final-folder"), queryParams.inFolder)
+    assertEquals("final-folder", queryParams.convertToMap()["in"])
+  }
+
+  @Test
+  fun `overriding string inFolder with list in builder works correctly`() {
+    val queryParams = ListThreadsQueryParams.Builder()
+      .inFolder("initial-folder") // Set string first
+      .inFolder(listOf("folder1", "folder2")) // Override with list
+      .build()
+
+    assertEquals(listOf("folder1", "folder2"), queryParams.inFolder)
+    assertEquals("folder1", queryParams.convertToMap()["in"])
+  }
+}


### PR DESCRIPTION
# What did you do?

The Nylas API only supports filtering by a single folder ID, but the SDK
was incorrectly accepting a List<String> and sending all items to the API.
The API would only use the last item, causing unexpected behavior.

Changes:
- Modified ListThreadsQueryParams.convertToMap() to use only the first
  folder ID from a list, matching API behavior
- Added new inFolder(String) method in Builder (recommended approach)
- Deprecated inFolder(List<String>) method with clear migration guidance
- Added comprehensive test coverage for all scenarios
- Updated documentation with API limitations and usage examples
- Maintained full backward compatibility

The fix ensures proper API behavior while providing a clear migration
path for users. In the next major version, the parameter will be
changed to accept only a String.

Fixes issue where only the last folder ID was used when multiple
folder IDs were provided in the inFolder parameter.

## 📋 Usage Examples
### New recommended approach:
```kt
val queryParams = ListThreadsQueryParams.Builder()
    .inFolder("folder-id-123")
    .limit(10)
    .build()
```
### Deprecated but still working:
```kt
val queryParams = ListThreadsQueryParams.Builder()
    .inFolder(listOf("folder1", "folder2"))  // Only "folder1" will be used
    .limit(10)
    .build()
```

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.