### PR TITLE
v2.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Nylas Java SDK Changelog
 
 
-## [Unreleased]
+## [2.10.0] - Release 2025-06-12
 
 ### Added
 * Support for `include_tracking_options` and `raw_mime` values in `MessageFields` enum

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have a question about the Nylas Communications Platform, [contact Nylas S
 If you're using Gradle, add the following to the dependencies section of `build.gradle`:
 
 ```groovy
-implementation("com.nylas.sdk:nylas:2.8.0")
+implementation("com.nylas.sdk:nylas:2.10.0")
 ```
 
 ### Build from source

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.9.0
+version=2.10.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Changelog
### Added
* Support for `include_tracking_options` and `raw_mime` values in `MessageFields` enum
* Support for `tracking_options` field in `Message` model to access message tracking settings
* Support for `raw_mime` field in `Message` model to access Base64url-encoded message data
* Support for query parameters in `Messages.find()` method to specify fields like `include_tracking_options` and `raw_mime`
* Added `Builder` pattern to `FindMessageQueryParams` for consistency with other query parameter classes
* Support for `single_level` query parameter in `ListFoldersQueryParams` for Microsoft accounts to control folder hierarchy traversal
* Added folder examples demonstrating the new `single_level` parameter usage in both Java and Kotlin

### Fixed
* Fixed `ListThreadsQueryParams.inFolder` parameter to properly handle single folder ID filtering as expected by the Nylas API. The API only supports filtering by a single folder ID, but the SDK was incorrectly accepting a list and only using the last item. Now the SDK uses the first item from a list if provided and includes overloaded `inFolder(String)` method in the Builder for new code. The list-based method is deprecated and will be changed to String in the next major version for backwards compatibility.

### Deprecated
* `ListThreadsQueryParams.Builder.inFolder(List<String>)` is deprecated in favor of `inFolder(String)`. The Nylas API only supports filtering by a single folder ID. In a future major version, this parameter will be changed to accept only a String.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.