### PR TITLE
Added `logo_url` and `show_nylas_branding` options and ability to turn off Nylas branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Nylas Java SDK Changelog
 
 
+## [2.11.0] - Release 2025-06-13
+
+### Added
+* Support for `logo` field in `EmailTemplate` class to specify a custom logo URL for booking emails
+* Support for `show_nylas_branding` field in `EmailTemplate` class to control Nylas branding visibility in booking emails
+* Added `Builder` pattern to `EmailTemplate` class for consistent SDK experience with new `logo()` and `showNylasBranding()` methods
+* Enhanced scheduler configuration support to allow complete email template customization for booking confirmations
+
 ## [2.10.0] - Release 2025-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Nylas Java SDK Changelog
 
 
-## [2.11.0] - Release 2025-06-13
+## [Unreleased]
 
 ### Added
 * Support for `logo` field in `EmailTemplate` class to specify a custom logo URL for booking emails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 ### Added
 * Support for `logo` field in `EmailTemplate` class to specify a custom logo URL for booking emails
 * Support for `show_nylas_branding` field in `EmailTemplate` class to control Nylas branding visibility in booking emails
-* Added `Builder` pattern to `EmailTemplate` class for consistent SDK experience with new `logo()` and `showNylasBranding()` methods
-* Enhanced scheduler configuration support to allow complete email template customization for booking confirmations
 
 ## [2.10.0] - Release 2025-06-12
 

--- a/src/main/kotlin/com/nylas/models/ConfigurationSchedulerSettings.kt
+++ b/src/main/kotlin/com/nylas/models/ConfigurationSchedulerSettings.kt
@@ -262,7 +262,61 @@ data class EmailTemplate(
    */
   @Json(name = "booking_confirmed")
   val bookingConfirmed: BookingConfirmedTemplate? = null,
-)
+  /**
+   * URL of a custom logo to appear in booking emails.
+   */
+  @Json(name = "logo")
+  val logo: String? = null,
+  /**
+   * Boolean flag to toggle Nylas branding visibility.
+   */
+  @Json(name = "show_nylas_branding")
+  val showNylasBranding: Boolean? = null,
+) {
+  /**
+   * Builder for [EmailTemplate].
+   */
+  class Builder {
+    private var bookingConfirmed: BookingConfirmedTemplate? = null
+    private var logo: String? = null
+    private var showNylasBranding: Boolean? = null
+
+    /**
+     * Set the configurable settings specifically for booking confirmed emails.
+     *
+     * @param bookingConfirmed Configurable settings specifically for booking confirmed emails.
+     * @return The builder.
+     */
+    fun bookingConfirmed(bookingConfirmed: BookingConfirmedTemplate) = apply { this.bookingConfirmed = bookingConfirmed }
+
+    /**
+     * Set the URL of a custom logo to appear in booking emails.
+     *
+     * @param logo URL of a custom logo to appear in booking emails.
+     * @return The builder.
+     */
+    fun logo(logo: String) = apply { this.logo = logo }
+
+    /**
+     * Set the boolean flag to toggle Nylas branding visibility.
+     *
+     * @param showNylasBranding Boolean flag to toggle Nylas branding visibility.
+     * @return The builder.
+     */
+    fun showNylasBranding(showNylasBranding: Boolean) = apply { this.showNylasBranding = showNylasBranding }
+
+    /**
+     * Build the [EmailTemplate].
+     *
+     * @return The [EmailTemplate]
+     */
+    fun build() = EmailTemplate(
+      bookingConfirmed,
+      logo,
+      showNylasBranding,
+    )
+  }
+}
 
 /**
  * Class representation of booking confirmed template settings.

--- a/src/test/kotlin/com/nylas/resources/ConfigurationsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/ConfigurationsTest.kt
@@ -182,6 +182,54 @@ class ConfigurationsTest {
       assertEquals("Test", config.participants.first().name)
       assertEquals("", config.participants.first().timezone)
     }
+
+    @Test
+    fun `EmailTemplate with new fields serializes properly`() {
+      val adapter = JsonHelper.moshi().adapter(EmailTemplate::class.java)
+      val jsonBuffer = Buffer().writeUtf8(
+        """
+        {
+          "booking_confirmed": {
+            "title": "Custom Booking Title",
+            "body": "Thank you for booking with us!"
+          },
+          "logo": "https://example.com/logo.png",
+          "show_nylas_branding": false
+        }
+        """.trimIndent(),
+      )
+
+      val emailTemplate = adapter.fromJson(jsonBuffer)!!
+      assertIs<EmailTemplate>(emailTemplate)
+      assertEquals("https://example.com/logo.png", emailTemplate.logo)
+      assertEquals(false, emailTemplate.showNylasBranding)
+      assertEquals("Custom Booking Title", emailTemplate.bookingConfirmed?.title)
+      assertEquals("Thank you for booking with us!", emailTemplate.bookingConfirmed?.body)
+
+      // Test serialization back to JSON
+      val serializedJson = adapter.toJson(emailTemplate)
+      assert(serializedJson.contains("\"logo\":\"https://example.com/logo.png\""))
+      assert(serializedJson.contains("\"show_nylas_branding\":false"))
+    }
+
+    @Test
+    fun `EmailTemplate Builder works correctly`() {
+      val bookingConfirmed = BookingConfirmedTemplate(
+        title = "Custom Title",
+        body = "Custom Body"
+      )
+      
+      val emailTemplate = EmailTemplate.Builder()
+        .bookingConfirmed(bookingConfirmed)
+        .logo("https://company.com/logo.svg")
+        .showNylasBranding(true)
+        .build()
+
+      assertEquals("https://company.com/logo.svg", emailTemplate.logo)
+      assertEquals(true, emailTemplate.showNylasBranding)
+      assertEquals("Custom Title", emailTemplate.bookingConfirmed?.title)
+      assertEquals("Custom Body", emailTemplate.bookingConfirmed?.body)
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/nylas/resources/ConfigurationsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/ConfigurationsTest.kt
@@ -216,9 +216,9 @@ class ConfigurationsTest {
     fun `EmailTemplate Builder works correctly`() {
       val bookingConfirmed = BookingConfirmedTemplate(
         title = "Custom Title",
-        body = "Custom Body"
+        body = "Custom Body",
       )
-      
+
       val emailTemplate = EmailTemplate.Builder()
         .bookingConfirmed(bookingConfirmed)
         .logo("https://company.com/logo.svg")


### PR DESCRIPTION
Added support for two missing fields (logo_url & showNylasBranding ) in the EmailTemplate class that were documented in the Scheduler API Reference but not implemented in the Java/Kotlin SDK.

- Added proper JSON serialization with "Json" annotations ("logo", "show_nylas_branding")
- Maintained backward compatibility - all new fields are optional
- Included in Changelog


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.