### PR TITLE
Add support for Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 * Support for `show_nylas_branding` field in `EmailTemplate` class to control Nylas branding visibility in booking emails
 * Support for `metadata` field type in `AdditionalFieldType` enum for scheduler additional fields
 
-### Fixed
-* Missing `metadata` field type in `AdditionalFieldType` enum that was supported by the API but not available in the SDK
-
 ## [2.10.0] - Release 2025-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ### Added
 * Support for `logo` field in `EmailTemplate` class to specify a custom logo URL for booking emails
 * Support for `show_nylas_branding` field in `EmailTemplate` class to control Nylas branding visibility in booking emails
+* Support for `metadata` field type in `AdditionalFieldType` enum for scheduler additional fields
+
+### Fixed
+* Missing `metadata` field type in `AdditionalFieldType` enum that was supported by the API but not available in the SDK
 
 ## [2.10.0] - Release 2025-06-12
 

--- a/src/main/kotlin/com/nylas/models/ConfigurationSchedulerSettings.kt
+++ b/src/main/kotlin/com/nylas/models/ConfigurationSchedulerSettings.kt
@@ -225,7 +225,7 @@ data class AdditionalField(
   val label: String,
   /**
    * The field type.
-   * Supported values are text, multi_line_text, email, phone_number, dropdown, date, checkbox, and radio_button.
+   * Supported values are text, multi_line_text, email, phone_number, dropdown, date, checkbox, radio_button, and metadata.
    */
   @Json(name = "type")
   val type: AdditionalFieldType,
@@ -361,6 +361,9 @@ enum class AdditionalFieldType {
 
   @Json(name = "radio_button")
   RADIO_BUTTON,
+
+  @Json(name = "metadata")
+  METADATA,
 }
 
 /**


### PR DESCRIPTION
Fixed missing metadata field type in AdditionalFieldType enum that was supported by the API but not available in the SDK.
Changes

- Added METADATA enum value with "Json"(name = "metadata") annotation
- Updated documentation to include metadata in supported field types
- Added tests for serialization and API integration

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.