### PR TITLE
feat: add dedicated conferencing provider enums for create and update operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+### Added
+* `CreateEventAutoConferencingProvider` enum for autocreate conferencing providers in event creation
+* `CreateEventManualConferencingProvider` enum for manual conferencing providers in event creation
+* `UpdateEventAutoConferencingProvider` enum for autocreate conferencing providers in event updates  
+* `UpdateEventManualConferencingProvider` enum for manual conferencing providers in event updates
+
+### Changed
+* Enhanced `CreateEventRequest.Conferencing` to use dedicated provider enums while maintaining backward compatibility
+* Enhanced `UpdateEventRequest.Conferencing` to use dedicated provider enums while maintaining backward compatibility
+
+### Deprecated
+* `CreateEventRequest.Conferencing.Autocreate.fromConferencingProvider()` - Use `CreateEventAutoConferencingProvider` instead
+* `CreateEventRequest.Conferencing.Details.fromConferencingProvider()` - Use `CreateEventManualConferencingProvider` instead
+* `UpdateEventRequest.Conferencing.Autocreate.fromConferencingProvider()` - Use `UpdateEventAutoConferencingProvider` instead
+* `UpdateEventRequest.Conferencing.Details.fromConferencingProvider()` - Use `UpdateEventManualConferencingProvider` instead
+
 ## [2.12.0]
 
 ### Added

--- a/src/main/kotlin/com/nylas/models/ConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/ConferencingProvider.kt
@@ -6,11 +6,11 @@ import com.squareup.moshi.Json
  * Enum for the different conferencing providers.
  */
 enum class ConferencingProvider {
-  @Json(name = "Zoom Meeting")
-  ZOOM_MEETING,
-
   @Json(name = "Google Meet")
   GOOGLE_MEET,
+
+  @Json(name = "GoToMeeting")
+  GOTOMEETING,
 
   @Json(name = "Microsoft Teams")
   MICROSOFT_TEAMS,
@@ -18,11 +18,8 @@ enum class ConferencingProvider {
   @Json(name = "WebEx")
   WEBEX,
 
-  @Json(name = "GoToMeeting")
-  GOTOMEETING,
-
-  @Json(name = "skypeForConsumer")
-  SKYPE_FOR_CONSUMER,
+  @Json(name = "Zoom Meeting")
+  ZOOM_MEETING,
 
   @Json(name = "unknown")
   UNKNOWN,

--- a/src/main/kotlin/com/nylas/models/CreateEventAutoConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/CreateEventAutoConferencingProvider.kt
@@ -1,0 +1,17 @@
+package com.nylas.models
+
+import com.squareup.moshi.Json
+
+/**
+ * Enum for the different conferencing providers that can be used to auto-create a meeting.
+ */
+enum class CreateEventAutoConferencingProvider {
+  @Json(name = "Google Meet")
+  GOOGLE_MEET,
+
+  @Json(name = "Zoom Meeting")
+  ZOOM_MEETING,
+
+  @Json(name = "Microsoft Teams")
+  MICROSOFT_TEAMS,
+}

--- a/src/main/kotlin/com/nylas/models/CreateEventManualConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/CreateEventManualConferencingProvider.kt
@@ -1,0 +1,26 @@
+package com.nylas.models
+
+import com.squareup.moshi.Json
+
+/**
+ * Enum for the different conferencing providers that can be used to manually create a meeting.
+ */
+enum class CreateEventManualConferencingProvider {
+  @Json(name = "Google Meet")
+  GOOGLE_MEET,
+
+  @Json(name = "Zoom Meeting")
+  ZOOM_MEETING,
+
+  @Json(name = "Microsoft Teams")
+  MICROSOFT_TEAMS,
+
+  @Json(name = "Teams for Business")
+  TEAMS_FOR_BUSINESS,
+
+  @Json(name = "Skype for Business")
+  SKYPE_FOR_BUSINESS,
+
+  @Json(name = "Skype for Consumer")
+  SKYPE_FOR_CONSUMER,
+}

--- a/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
@@ -321,14 +321,41 @@ data class CreateEventRequest(
        * The conferencing provider.
        */
       @Json(name = "provider")
-      val provider: ConferencingProvider,
+      val provider: CreateEventAutoConferencingProvider,
       /**
        * Empty dict to indicate an intention to autocreate a video link.
        * Additional provider settings may be included in autocreate.settings, but Nylas does not validate these.
        */
       @Json(name = "autocreate")
       val autocreate: Map<String, Any> = emptyMap(),
-    ) : Conferencing()
+    ) : Conferencing() {
+      companion object {
+        /**
+         * Create an Autocreate conferencing object using the original ConferencingProvider enum.
+         * @param provider The conferencing provider from the original enum
+         * @param autocreate Empty dict to indicate an intention to autocreate a video link
+         * @return Autocreate object with converted provider
+         * @deprecated Use CreateEventAutoConferencingProvider instead. This method will be removed in a future version.
+         */
+        @Deprecated(
+          message = "Use CreateEventAutoConferencingProvider instead of ConferencingProvider",
+          replaceWith = ReplaceWith("Autocreate(CreateEventAutoConferencingProvider.fromConferencingProvider(provider), autocreate)"),
+        )
+        @JvmStatic
+        fun fromConferencingProvider(
+          provider: ConferencingProvider,
+          autocreate: Map<String, Any> = emptyMap(),
+        ): Autocreate {
+          val newProvider = when (provider) {
+            ConferencingProvider.GOOGLE_MEET -> CreateEventAutoConferencingProvider.GOOGLE_MEET
+            ConferencingProvider.ZOOM_MEETING -> CreateEventAutoConferencingProvider.ZOOM_MEETING
+            ConferencingProvider.MICROSOFT_TEAMS -> CreateEventAutoConferencingProvider.MICROSOFT_TEAMS
+            else -> throw IllegalArgumentException("Provider $provider is not supported for autocreate conferencing. Use CreateEventAutoConferencingProvider instead.")
+          }
+          return Autocreate(newProvider, autocreate)
+        }
+      }
+    }
 
     /**
      * Class representation of a conferencing details object
@@ -338,13 +365,42 @@ data class CreateEventRequest(
        * The conferencing provider.
        */
       @Json(name = "provider")
-      val provider: ConferencingProvider,
+      val provider: CreateEventManualConferencingProvider,
       /**
        * The conferencing details
        */
       @Json(name = "details")
       val details: Config,
     ) : Conferencing() {
+      companion object {
+        /**
+         * Create a Details conferencing object using the original ConferencingProvider enum.
+         * @param provider The conferencing provider from the original enum
+         * @param details The conferencing details config
+         * @return Details object with converted provider
+         * @deprecated Use CreateEventManualConferencingProvider instead. This method will be removed in a future version.
+         */
+        @Deprecated(
+          message = "Use CreateEventManualConferencingProvider instead of ConferencingProvider",
+          replaceWith = ReplaceWith("Details(CreateEventManualConferencingProvider.fromConferencingProvider(provider), details)"),
+        )
+        @JvmStatic
+        fun fromConferencingProvider(
+          provider: ConferencingProvider,
+          details: Config,
+        ): Details {
+          val newProvider = when (provider) {
+            ConferencingProvider.GOOGLE_MEET -> CreateEventManualConferencingProvider.GOOGLE_MEET
+            ConferencingProvider.ZOOM_MEETING -> CreateEventManualConferencingProvider.ZOOM_MEETING
+            ConferencingProvider.MICROSOFT_TEAMS -> CreateEventManualConferencingProvider.MICROSOFT_TEAMS
+            ConferencingProvider.GOTOMEETING -> throw IllegalArgumentException("GoToMeeting is not supported in CreateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.WEBEX -> throw IllegalArgumentException("WebEx is not supported in CreateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.UNKNOWN -> throw IllegalArgumentException("Unknown provider is not supported for event creation. Use CreateEventManualConferencingProvider instead.")
+          }
+          return Details(newProvider, details)
+        }
+      }
+
       /**
        * Class representation of a conferencing details config object
        * @property meetingCode The conferencing meeting code. Used for Zoom.

--- a/src/main/kotlin/com/nylas/models/UpdateEventAutoConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventAutoConferencingProvider.kt
@@ -1,0 +1,17 @@
+package com.nylas.models
+
+import com.squareup.moshi.Json
+
+/**
+ * Enum for the different conferencing providers that can be used to auto-create a meeting when updating events.
+ */
+enum class UpdateEventAutoConferencingProvider {
+  @Json(name = "Google Meet")
+  GOOGLE_MEET,
+
+  @Json(name = "Zoom Meeting")
+  ZOOM_MEETING,
+
+  @Json(name = "Microsoft Teams")
+  MICROSOFT_TEAMS,
+}

--- a/src/main/kotlin/com/nylas/models/UpdateEventManualConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventManualConferencingProvider.kt
@@ -1,0 +1,26 @@
+package com.nylas.models
+
+import com.squareup.moshi.Json
+
+/**
+ * Enum for the different conferencing providers that can be used to manually create a meeting when updating events.
+ */
+enum class UpdateEventManualConferencingProvider {
+  @Json(name = "Google Meet")
+  GOOGLE_MEET,
+
+  @Json(name = "Zoom Meeting")
+  ZOOM_MEETING,
+
+  @Json(name = "Microsoft Teams")
+  MICROSOFT_TEAMS,
+
+  @Json(name = "Teams for Business")
+  TEAMS_FOR_BUSINESS,
+
+  @Json(name = "Skype for Business")
+  SKYPE_FOR_BUSINESS,
+
+  @Json(name = "Skype for Consumer")
+  SKYPE_FOR_CONSUMER,
+}

--- a/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
@@ -354,7 +354,7 @@ data class UpdateEventRequest(
        * The conferencing provider.
        */
       @Json(name = "provider")
-      val provider: ConferencingProvider? = null,
+      val provider: UpdateEventAutoConferencingProvider? = null,
       /**
        * Empty dict to indicate an intention to autocreate a video link.
        * Additional provider settings may be included in autocreate.settings, but Nylas does not validate these.
@@ -362,11 +362,38 @@ data class UpdateEventRequest(
       @Json(name = "autocreate")
       val autocreate: Map<String, Any>? = null,
     ) : Conferencing() {
+      companion object {
+        /**
+         * Create an Autocreate conferencing object using the original ConferencingProvider enum.
+         * @param provider The conferencing provider from the original enum
+         * @param autocreate Empty dict to indicate an intention to autocreate a video link
+         * @return Autocreate object with converted provider
+         * @deprecated Use UpdateEventAutoConferencingProvider instead. This method will be removed in a future version.
+         */
+        @Deprecated(
+          message = "Use UpdateEventAutoConferencingProvider instead of ConferencingProvider",
+          replaceWith = ReplaceWith("Autocreate(UpdateEventAutoConferencingProvider.fromConferencingProvider(provider), autocreate)"),
+        )
+        @JvmStatic
+        fun fromConferencingProvider(
+          provider: ConferencingProvider,
+          autocreate: Map<String, Any>? = null,
+        ): Autocreate {
+          val newProvider = when (provider) {
+            ConferencingProvider.GOOGLE_MEET -> UpdateEventAutoConferencingProvider.GOOGLE_MEET
+            ConferencingProvider.ZOOM_MEETING -> UpdateEventAutoConferencingProvider.ZOOM_MEETING
+            ConferencingProvider.MICROSOFT_TEAMS -> UpdateEventAutoConferencingProvider.MICROSOFT_TEAMS
+            else -> throw IllegalArgumentException("Provider $provider is not supported for autocreate conferencing. Use UpdateEventAutoConferencingProvider instead.")
+          }
+          return Autocreate(newProvider, autocreate)
+        }
+      }
+
       /**
        * Builder for [Autocreate].
        */
       class Builder {
-        private var provider: ConferencingProvider? = null
+        private var provider: UpdateEventAutoConferencingProvider? = null
         private var autocreate: Map<String, Any>? = null
 
         /**
@@ -374,7 +401,7 @@ data class UpdateEventRequest(
          * @param provider The conferencing provider.
          * @return The builder.
          */
-        fun provider(provider: ConferencingProvider) = apply { this.provider = provider }
+        fun provider(provider: UpdateEventAutoConferencingProvider) = apply { this.provider = provider }
 
         /**
          * Set the autocreate settings.
@@ -400,13 +427,42 @@ data class UpdateEventRequest(
        * The conferencing provider.
        */
       @Json(name = "provider")
-      val provider: ConferencingProvider? = null,
+      val provider: UpdateEventManualConferencingProvider? = null,
       /**
        * The conferencing details
        */
       @Json(name = "details")
       val details: Config? = null,
     ) : Conferencing() {
+      companion object {
+        /**
+         * Create a Details conferencing object using the original ConferencingProvider enum.
+         * @param provider The conferencing provider from the original enum
+         * @param details The conferencing details config
+         * @return Details object with converted provider
+         * @deprecated Use UpdateEventManualConferencingProvider instead. This method will be removed in a future version.
+         */
+        @Deprecated(
+          message = "Use UpdateEventManualConferencingProvider instead of ConferencingProvider",
+          replaceWith = ReplaceWith("Details(UpdateEventManualConferencingProvider.fromConferencingProvider(provider), details)"),
+        )
+        @JvmStatic
+        fun fromConferencingProvider(
+          provider: ConferencingProvider,
+          details: Config? = null,
+        ): Details {
+          val newProvider = when (provider) {
+            ConferencingProvider.GOOGLE_MEET -> UpdateEventManualConferencingProvider.GOOGLE_MEET
+            ConferencingProvider.ZOOM_MEETING -> UpdateEventManualConferencingProvider.ZOOM_MEETING
+            ConferencingProvider.MICROSOFT_TEAMS -> UpdateEventManualConferencingProvider.MICROSOFT_TEAMS
+            ConferencingProvider.GOTOMEETING -> throw IllegalArgumentException("GoToMeeting is not supported in UpdateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.WEBEX -> throw IllegalArgumentException("WebEx is not supported in UpdateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.UNKNOWN -> throw IllegalArgumentException("Unknown provider is not supported for event updates. Use UpdateEventManualConferencingProvider instead.")
+          }
+          return Details(newProvider, details)
+        }
+      }
+
       /**
        * Class representation of a conferencing details config object
        * @property meetingCode The conferencing meeting code. Used for Zoom.
@@ -474,7 +530,7 @@ data class UpdateEventRequest(
        * Builder for [Details].
        */
       class Builder {
-        private var provider: ConferencingProvider? = null
+        private var provider: UpdateEventManualConferencingProvider? = null
         private var details: Config? = null
 
         /**
@@ -482,7 +538,7 @@ data class UpdateEventRequest(
          * @param provider The conferencing provider.
          * @return The builder.
          */
-        fun provider(provider: ConferencingProvider) = apply { this.provider = provider }
+        fun provider(provider: UpdateEventManualConferencingProvider) = apply { this.provider = provider }
 
         /**
          * Set the conferencing details.


### PR DESCRIPTION
# What did you do?

### Added
* `CreateEventAutoConferencingProvider` enum for autocreate conferencing providers in event creation
* `CreateEventManualConferencingProvider` enum for manual conferencing providers in event creation
* `UpdateEventAutoConferencingProvider` enum for autocreate conferencing providers in event updates  
* `UpdateEventManualConferencingProvider` enum for manual conferencing providers in event updates

### Changed
* Enhanced `CreateEventRequest.Conferencing` to use dedicated provider enums while maintaining backward compatibility
* Enhanced `UpdateEventRequest.Conferencing` to use dedicated provider enums while maintaining backward compatibility

### Deprecated
* `CreateEventRequest.Conferencing.Autocreate.fromConferencingProvider()` - Use `CreateEventAutoConferencingProvider` instead
* `CreateEventRequest.Conferencing.Details.fromConferencingProvider()` - Use `CreateEventManualConferencingProvider` instead
* `UpdateEventRequest.Conferencing.Autocreate.fromConferencingProvider()` - Use `UpdateEventAutoConferencingProvider` instead
* `UpdateEventRequest.Conferencing.Details.fromConferencingProvider()` - Use `UpdateEventManualConferencingProvider` instead

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.