### PR TITLE
Release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
+## [2.13.0]
 
 ### Added
 * `CreateEventAutoConferencingProvider` enum for autocreate conferencing providers in event creation

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have a question about the Nylas Communications Platform, [contact Nylas S
 If you're using Gradle, add the following to the dependencies section of `build.gradle`:
 
 ```groovy
-implementation("com.nylas.sdk:nylas:2.12.0")
+implementation("com.nylas.sdk:nylas:2.13.0")
 ```
 
 ### Build from source
@@ -42,7 +42,7 @@ git clone https://github.com/nylas/nylas-java.git && cd nylas-java
 ./gradlew build uberJar
 ```
 
-This creates a new jar file in `build/libs/nylas-java-sdk-2.12.0-uber.jar`.
+This creates a new jar file in `build/libs/nylas-java-sdk-2.13.0-uber.jar`.
 
 See the Gradle documentation on [Building Libraries](https://guides.gradle.org/building-java-libraries/)
 or the [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html) for more information.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.12.0
+version=2.13.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Changelog

### Added
* `CreateEventAutoConferencingProvider` enum for autocreate conferencing providers in event creation
* `CreateEventManualConferencingProvider` enum for manual conferencing providers in event creation
* `UpdateEventAutoConferencingProvider` enum for autocreate conferencing providers in event updates  
* `UpdateEventManualConferencingProvider` enum for manual conferencing providers in event updates
### Changed
* Enhanced `CreateEventRequest.Conferencing` to use dedicated provider enums while maintaining backward compatibility
* Enhanced `UpdateEventRequest.Conferencing` to use dedicated provider enums while maintaining backward compatibility
### Deprecated
* `CreateEventRequest.Conferencing.Autocreate.fromConferencingProvider()` - Use `CreateEventAutoConferencingProvider` instead
* `CreateEventRequest.Conferencing.Details.fromConferencingProvider()` - Use `CreateEventManualConferencingProvider` instead
* `UpdateEventRequest.Conferencing.Autocreate.fromConferencingProvider()` - Use `UpdateEventAutoConferencingProvider` instead
* `UpdateEventRequest.Conferencing.Details.fromConferencingProvider()` - Use `UpdateEventManualConferencingProvider` instead

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.