### PR TITLE
CUST-4675 added 'Skype for Consumer' and 'Skype for Business' to conferencing providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+### Added
+* `Skype for Consumer` as a conferencing provider to ConferencingProvider
+* `Skype for Business` as a conferencing provider to ConferencingProvider
+
 ## [2.13.0]
 
 ### Added

--- a/src/main/kotlin/com/nylas/models/ConferencingProvider.kt
+++ b/src/main/kotlin/com/nylas/models/ConferencingProvider.kt
@@ -21,6 +21,12 @@ enum class ConferencingProvider {
   @Json(name = "Zoom Meeting")
   ZOOM_MEETING,
 
+  @Json(name = "Skype for Consumer")
+  SKYPE_FOR_CONSUMER,
+
+  @Json(name = "Skype for Business")
+  SKYPE_FOR_BUSINESS,
+
   @Json(name = "unknown")
   UNKNOWN,
 }

--- a/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
@@ -395,6 +395,8 @@ data class CreateEventRequest(
             ConferencingProvider.MICROSOFT_TEAMS -> CreateEventManualConferencingProvider.MICROSOFT_TEAMS
             ConferencingProvider.GOTOMEETING -> throw IllegalArgumentException("GoToMeeting is not supported in CreateEventManualConferencingProvider. Use the new enum directly.")
             ConferencingProvider.WEBEX -> throw IllegalArgumentException("WebEx is not supported in CreateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.SKYPE_FOR_CONSUMER -> throw IllegalArgumentException("Skype for Consumer is not supported in CreateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.SKYPE_FOR_BUSINESS -> throw IllegalArgumentException("Skype for Business is not supported in CreateEventManualConferencingProvider. Use the new enum directly.")
             ConferencingProvider.UNKNOWN -> throw IllegalArgumentException("Unknown provider is not supported for event creation. Use CreateEventManualConferencingProvider instead.")
           }
           return Details(newProvider, details)

--- a/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
@@ -457,6 +457,8 @@ data class UpdateEventRequest(
             ConferencingProvider.MICROSOFT_TEAMS -> UpdateEventManualConferencingProvider.MICROSOFT_TEAMS
             ConferencingProvider.GOTOMEETING -> throw IllegalArgumentException("GoToMeeting is not supported in UpdateEventManualConferencingProvider. Use the new enum directly.")
             ConferencingProvider.WEBEX -> throw IllegalArgumentException("WebEx is not supported in UpdateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.SKYPE_FOR_CONSUMER -> throw IllegalArgumentException("Skype for Consumer is not supported in UpdateEventManualConferencingProvider. Use the new enum directly.")
+            ConferencingProvider.SKYPE_FOR_BUSINESS -> throw IllegalArgumentException("Skype for Business is not supported in UpdateEventManualConferencingProvider. Use the new enum directly.")
             ConferencingProvider.UNKNOWN -> throw IllegalArgumentException("Unknown provider is not supported for event updates. Use UpdateEventManualConferencingProvider instead.")
           }
           return Details(newProvider, details)


### PR DESCRIPTION
The SDK was failing to validate the responses due to these missing in the ConferencingProvider model.

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.