### PR TITLE
Release v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
+## [2.13.1]
 
-### Added
-* `Skype for Consumer` as a conferencing provider to ConferencingProvider
-* `Skype for Business` as a conferencing provider to ConferencingProvider
+### Fixed
+* Added missing `Skype for Consumer` as a conferencing provider to ConferencingProvider
+* Added missing `Skype for Business` as a conferencing provider to ConferencingProvider
 
 ## [2.13.0]
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have a question about the Nylas Communications Platform, [contact Nylas S
 If you're using Gradle, add the following to the dependencies section of `build.gradle`:
 
 ```groovy
-implementation("com.nylas.sdk:nylas:2.13.0")
+implementation("com.nylas.sdk:nylas:2.13.1")
 ```
 
 ### Build from source
@@ -42,7 +42,7 @@ git clone https://github.com/nylas/nylas-java.git && cd nylas-java
 ./gradlew build uberJar
 ```
 
-This creates a new jar file in `build/libs/nylas-java-sdk-2.13.0-uber.jar`.
+This creates a new jar file in `build/libs/nylas-java-sdk-2.13.1-uber.jar`.
 
 See the Gradle documentation on [Building Libraries](https://guides.gradle.org/building-java-libraries/)
 or the [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html) for more information.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.13.0
+version=2.13.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
# Changelog

### Fixed
* Added missing `Skype for Consumer` as a conferencing provider to ConferencingProvider
* Added missing `Skype for Business` as a conferencing provider to ConferencingProvider


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.