### PR TITLE
CUST-3867 changed SendMessageRequest.sendAt to Long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+### Changed
+* `SendMessageRequest.sendAt` field changed from `Int?` to `Long?` to support Unix timestamps beyond 2038. Maintains backward compatibility through method overloading - existing `Int` parameters are automatically converted to `Long`. **Note:** Kotlin users passing integer literals may need to specify type explicitly (e.g., `1620000000L` or `1620000000 as Int`).
+
 ## [2.13.1]
 
 ### Fixed

--- a/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
+++ b/src/main/kotlin/com/nylas/models/SendMessageRequest.kt
@@ -56,7 +56,7 @@ data class SendMessageRequest(
    * Unix timestamp to send the message at.
    */
   @Json(name = "send_at")
-  val sendAt: Int? = null,
+  val sendAt: Long? = null,
   /**
    * The ID of the message that you are replying to.
    */
@@ -94,7 +94,7 @@ data class SendMessageRequest(
     internal var subject: String? = null
     private var body: String? = null
     private var starred: Boolean? = null
-    private var sendAt: Int? = null
+    private var sendAt: Long? = null
     private var replyToMessageId: String? = null
     private var trackingOptions: TrackingOptions? = null
     private var useDraft: Boolean? = null
@@ -162,7 +162,14 @@ data class SendMessageRequest(
      * @param sendAt The unix timestamp to send the message at.
      * @return The builder.
      */
-    fun sendAt(sendAt: Int?) = apply { this.sendAt = sendAt }
+    fun sendAt(sendAt: Long?) = apply { this.sendAt = sendAt }
+
+    /**
+     * Sets the unix timestamp to send the message at.
+     * @param sendAt The unix timestamp to send the message at (automatically converted to Long).
+     * @return The builder.
+     */
+    fun sendAt(sendAt: Int?) = apply { this.sendAt = sendAt?.toLong() }
 
     /**
      * Sets the ID of the message that you are replying to.


### PR DESCRIPTION
Added a method overload that converts passed ints to Longs, so that the change is not breaking. There should be a warning thrown if Kotlin users pass int literals, but these can be ignored/corrected easily (and should not be happening anyway). Tested this thoroughly.
# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.