### PR TITLE
Release v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [v2.15.0] - Release 2026-02-21
+## [v2.15.0] - Release 2026-02-23
 
 ### Added
 * Multi-credential authentication support allowing multiple provider credentials per Connector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [v2.15.0] - Release 2026-02-23
+## [v2.15.0] - Release 2026-02-22
 
 ### Added
 * Multi-credential authentication support allowing multiple provider credentials per Connector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
+## [v2.15.0] - Release 2026-02-21
 
 ### Added
 * Multi-credential authentication support allowing multiple provider credentials per Connector

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have a question about the Nylas Communications Platform, [contact Nylas S
 If you're using Gradle, add the following to the dependencies section of `build.gradle`:
 
 ```groovy
-implementation("com.nylas.sdk:nylas:2.14.1")
+implementation("com.nylas.sdk:nylas:2.15.0")
 ```
 
 ### Build from source
@@ -42,7 +42,7 @@ git clone https://github.com/nylas/nylas-java.git && cd nylas-java
 ./gradlew build uberJar
 ```
 
-This creates a new jar file in `build/libs/nylas-java-sdk-2.14.1-uber.jar`.
+This creates a new jar file in `build/libs/nylas-java-sdk-2.15.0-uber.jar`.
 
 See the Gradle documentation on [Building Libraries](https://guides.gradle.org/building-java-libraries/)
 or the [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html) for more information.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.14.1
+version=2.15.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
### Added
* Multi-credential authentication support allowing multiple provider credentials per Connector
  - `CreateCredentialRequest.Connector` class for creating connector credentials with `client_id`, `client_secret`, and optional extra properties like `tenant`
  - `credentialId` field in `UrlForAuthenticationConfig` for hosted auth URL generation via `urlForOAuth2` and `urlForOAuth2PKCE`
  - `credentialId` field in `CreateGrantRequest` for custom authentication
  - `credentialId` field in `Grant` response model
  - `activeCredentialId` field in `Connector` response model
  - `activeCredentialId` field in `UpdateConnectorRequest` for setting the active credential on a Connector
* Enhanced `CredentialData.ConnectorOverride` to support optional `clientId` and `clientSecret` fields
* Support for `specific_time_availability` and `only_specific_time_availability` fields in `AvailabilityParticipant` to override open hours configurations for specific dates and time ranges
* `smtpRequired` field in `UrlForAuthenticationConfig` to ensure users enter their SMTP settings during hosted authentication

### Deprecated
* `CreateCredentialRequest.Override` - Use `CreateCredentialRequest.Connector` instead

https://nylas.atlassian.net/browse/TT-4495

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.