### PR TITLE
CUST-5203: add "maybe" to Event Status, use "maybe" instead of deprecated "tentative", and gracefully handle unknown status

### DIFF
--- a/src/main/kotlin/com/nylas/models/Event.kt
+++ b/src/main/kotlin/com/nylas/models/Event.kt
@@ -110,7 +110,7 @@ data class Event(
   @Json(name = "reminders")
   val reminders: Reminders? = null,
   /**
-   * Status of the event.
+   * Status of the event. Possible values: "confirmed", "tentative", "cancelled", "maybe".
    */
   @Json(name = "status")
   val status: EventStatus? = null,

--- a/src/main/kotlin/com/nylas/models/EventStatus.kt
+++ b/src/main/kotlin/com/nylas/models/EventStatus.kt
@@ -9,6 +9,9 @@ enum class EventStatus {
   @Json(name = "confirmed")
   CONFIRMED,
 
+  @Json(name = "maybe")
+  MAYBE,
+
   @Json(name = "tentative")
   TENTATIVE,
 

--- a/src/main/kotlin/com/nylas/models/EventStatus.kt
+++ b/src/main/kotlin/com/nylas/models/EventStatus.kt
@@ -12,6 +12,10 @@ enum class EventStatus {
   @Json(name = "maybe")
   MAYBE,
 
+  @Deprecated(
+    message = "Use MAYBE instead. TENTATIVE is a legacy alias and will be removed in a future release.",
+    replaceWith = ReplaceWith("MAYBE"),
+  )
   @Json(name = "tentative")
   TENTATIVE,
 

--- a/src/main/kotlin/com/nylas/util/EventStatusJsonAdapter.kt
+++ b/src/main/kotlin/com/nylas/util/EventStatusJsonAdapter.kt
@@ -1,0 +1,23 @@
+package com.nylas.util
+
+import com.nylas.models.EventStatus
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+import com.squareup.moshi.adapters.EnumJsonAdapter
+
+/**
+ * Handles EventStatus values without failing deserialization when the API returns a new status.
+ */
+class EventStatusJsonAdapter {
+  private val delegate = EnumJsonAdapter.create(EventStatus::class.java).withUnknownFallback(null)
+
+  @FromJson
+  fun fromJson(reader: JsonReader): EventStatus? = delegate.fromJson(reader)
+
+  @ToJson
+  fun toJson(writer: JsonWriter, value: EventStatus?) {
+    delegate.toJson(writer, value)
+  }
+}

--- a/src/main/kotlin/com/nylas/util/EventStatusJsonAdapter.kt
+++ b/src/main/kotlin/com/nylas/util/EventStatusJsonAdapter.kt
@@ -5,19 +5,33 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
-import com.squareup.moshi.adapters.EnumJsonAdapter
 
 /**
- * Handles EventStatus values without failing deserialization when the API returns a new status.
+ * Normalizes legacy event status values and avoids failing deserialization on new values.
  */
 class EventStatusJsonAdapter {
-  private val delegate = EnumJsonAdapter.create(EventStatus::class.java).withUnknownFallback(null)
-
   @FromJson
-  fun fromJson(reader: JsonReader): EventStatus? = delegate.fromJson(reader)
+  fun fromJson(reader: JsonReader): EventStatus? {
+    if (reader.peek() == JsonReader.Token.NULL) {
+      return reader.nextNull()
+    }
+
+    return when (reader.nextString()) {
+      "confirmed" -> EventStatus.CONFIRMED
+      "maybe", "tentative" -> EventStatus.MAYBE
+      "cancelled" -> EventStatus.CANCELLED
+      else -> null
+    }
+  }
 
   @ToJson
+  @Suppress("DEPRECATION")
   fun toJson(writer: JsonWriter, value: EventStatus?) {
-    delegate.toJson(writer, value)
+    when (value) {
+      null -> writer.nullValue()
+      EventStatus.CONFIRMED -> writer.value("confirmed")
+      EventStatus.MAYBE, EventStatus.TENTATIVE -> writer.value("maybe")
+      EventStatus.CANCELLED -> writer.value("cancelled")
+    }
   }
 }

--- a/src/main/kotlin/com/nylas/util/JsonHelper.kt
+++ b/src/main/kotlin/com/nylas/util/JsonHelper.kt
@@ -36,6 +36,7 @@ class JsonHelper {
       .add(IMessageAdapter())
       .add(UpdateConnectorAdapter())
       .add(CredentialDataAdapter())
+      .add(EventStatusJsonAdapter())
       .add(CreateAttachmentRequestAdapter())
       .add(MicrosoftAdminConsentCredentialDataAdapter())
       .add(GoogleServiceAccountCredentialDataAdapter())

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -224,6 +224,56 @@ class EventsTests {
     }
 
     @Test
+    fun `Event deserializes maybe status properly`() {
+      val adapter = JsonHelper.moshi().adapter(Event::class.java)
+      val jsonBuffer =
+        Buffer().writeUtf8(
+          """
+          {
+            "id": "5d3qmne77v32r8l4phyuksl2x",
+            "grant_id": "41009df5-bf11-4c97-aa18-b285b5f2e386",
+            "calendar_id": "7d93zl2palhxqdy6e5qinsakt",
+            "object": "event",
+            "status": "maybe",
+            "when": {
+              "date": "2024-06-18",
+              "object": "date"
+            }
+          }
+          """.trimIndent(),
+        )
+
+      val event = adapter.fromJson(jsonBuffer)!!
+
+      assertEquals(EventStatus.MAYBE, event.status)
+    }
+
+    @Test
+    fun `Event deserializes unknown status as null`() {
+      val adapter = JsonHelper.moshi().adapter(Event::class.java)
+      val jsonBuffer =
+        Buffer().writeUtf8(
+          """
+          {
+            "id": "5d3qmne77v32r8l4phyuksl2x",
+            "grant_id": "41009df5-bf11-4c97-aa18-b285b5f2e386",
+            "calendar_id": "7d93zl2palhxqdy6e5qinsakt",
+            "object": "event",
+            "status": "unexpected_status",
+            "when": {
+              "date": "2024-06-18",
+              "object": "date"
+            }
+          }
+          """.trimIndent(),
+        )
+
+      val event = adapter.fromJson(jsonBuffer)!!
+
+      assertEquals(null, event.status)
+    }
+
+    @Test
     fun `CreateEventAutoConferencingProvider serializes properly`() {
       val adapter = JsonHelper.moshi().adapter(CreateEventAutoConferencingProvider::class.java)
 

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -249,6 +249,31 @@ class EventsTests {
     }
 
     @Test
+    fun `Event deserializes tentative status as maybe`() {
+      val adapter = JsonHelper.moshi().adapter(Event::class.java)
+      val jsonBuffer =
+        Buffer().writeUtf8(
+          """
+          {
+            "id": "5d3qmne77v32r8l4phyuksl2x",
+            "grant_id": "41009df5-bf11-4c97-aa18-b285b5f2e386",
+            "calendar_id": "7d93zl2palhxqdy6e5qinsakt",
+            "object": "event",
+            "status": "tentative",
+            "when": {
+              "date": "2024-06-18",
+              "object": "date"
+            }
+          }
+          """.trimIndent(),
+        )
+
+      val event = adapter.fromJson(jsonBuffer)!!
+
+      assertEquals(EventStatus.MAYBE, event.status)
+    }
+
+    @Test
     fun `Event deserializes unknown status as null`() {
       val adapter = JsonHelper.moshi().adapter(Event::class.java)
       val jsonBuffer =
@@ -271,6 +296,15 @@ class EventsTests {
       val event = adapter.fromJson(jsonBuffer)!!
 
       assertEquals(null, event.status)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `Event status serializes tentative as maybe`() {
+      val adapter = JsonHelper.moshi().adapter(EventStatus::class.java)
+
+      assertEquals("\"maybe\"", adapter.toJson(EventStatus.MAYBE))
+      assertEquals("\"maybe\"", adapter.toJson(EventStatus.TENTATIVE))
     }
 
     @Test


### PR DESCRIPTION
Add "maybe" as an Event Status, and also add a graceful handler of unknown returned events instead of crashing with unknown JsonDataException (as described in the [ticket](https://nylas.atlassian.net/browse/CUST-5203)).

Also, "maybe" is the new standard for Event Status instead of "tentative" (which will be deprecated one time in the future).

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.