### PR TITLE
Add support for Google Calendar color_id field on Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+### Added
+* `colorId` field on `Event`, `CreateEventRequest`, and `UpdateEventRequest` for Google Calendar event colors, mapped to the `color_id` JSON property.
+  Valid values are strings `"1"` through `"11"`.
+  See [Google Calendar Colors](https://developers.google.com/calendar/api/v3/reference/colors).
+
 ## [v2.15.1] - Release 2026-03-30
 
 ### Changed

--- a/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
@@ -95,7 +95,8 @@ data class CreateEventRequest(
   @Json(name = "notetaker")
   val notetaker: EventNotetakerRequest? = null,
   /**
-   * The Google color ID for the event. (Currently) Only applies to Google Calendar events.
+   * The Google color ID for the event. Only supported by Google Calendar providers; ignored by other providers.
+   * Valid values are strings "1" through "11".
    * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
    */
   @Json(name = "color_id")
@@ -633,7 +634,8 @@ data class CreateEventRequest(
     fun notetaker(notetaker: EventNotetakerRequest) = apply { this.notetaker = notetaker }
 
     /**
-     * Set the Google color ID for the event. Only applies to Google Calendar events.
+     * Set the Google color ID for the event. Only supported by Google Calendar providers; ignored by other providers.
+     * Valid values are strings "1" through "11".
      * @param colorId The Google color ID.
      * @return The builder.
      * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>

--- a/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/CreateEventRequest.kt
@@ -94,6 +94,12 @@ data class CreateEventRequest(
    */
   @Json(name = "notetaker")
   val notetaker: EventNotetakerRequest? = null,
+  /**
+   * The Google color ID for the event. (Currently) Only applies to Google Calendar events.
+   * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
+   */
+  @Json(name = "color_id")
+  val colorId: String? = null,
 ) {
   /**
    * This sealed class represents the different types of event time configurations.
@@ -511,6 +517,7 @@ data class CreateEventRequest(
     private var capacity: Int? = null
     private var hideParticipant: Boolean? = null
     private var notetaker: EventNotetakerRequest? = null
+    private var colorId: String? = null
 
     /**
      * Set the event title.
@@ -626,6 +633,14 @@ data class CreateEventRequest(
     fun notetaker(notetaker: EventNotetakerRequest) = apply { this.notetaker = notetaker }
 
     /**
+     * Set the Google color ID for the event. Only applies to Google Calendar events.
+     * @param colorId The Google color ID.
+     * @return The builder.
+     * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
+     */
+    fun colorId(colorId: String) = apply { this.colorId = colorId }
+
+    /**
      * Builds the [CreateEventRequest] object.
      * @return [CreateEventRequest] object.
      */
@@ -647,6 +662,7 @@ data class CreateEventRequest(
         capacity,
         hideParticipant,
         notetaker,
+        colorId,
       )
   }
 }

--- a/src/main/kotlin/com/nylas/models/Event.kt
+++ b/src/main/kotlin/com/nylas/models/Event.kt
@@ -155,6 +155,12 @@ data class Event(
    */
   @Json(name = "original_start_time")
   val originalStartTime: Long? = null,
+  /**
+   * The Google color ID for the event. (Currently) Only applies to Google Calendar events.
+   * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
+   */
+  @Json(name = "color_id")
+  val colorId: String? = null,
 ) {
   /**
    * Get the type of object.

--- a/src/main/kotlin/com/nylas/models/Event.kt
+++ b/src/main/kotlin/com/nylas/models/Event.kt
@@ -156,7 +156,8 @@ data class Event(
   @Json(name = "original_start_time")
   val originalStartTime: Long? = null,
   /**
-   * The Google color ID for the event. (Currently) Only applies to Google Calendar events.
+   * The Google color ID for the event. Only supported by Google Calendar providers; ignored by other providers.
+   * Valid values are strings "1" through "11".
    * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
    */
   @Json(name = "color_id")

--- a/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
@@ -729,12 +729,12 @@ data class UpdateEventRequest(
 
     /**
      * Update the Google color ID for the event. Only supported by Google Calendar providers; ignored by other providers.
-     * Pass null to clear an existing color. Valid values are strings "1" through "11".
-     * @param colorId The Google color ID, or null to clear the color.
+     * Valid values are strings "1" through "11".
+     * @param colorId The Google color ID.
      * @return The builder.
      * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
      */
-    fun colorId(colorId: String?) = apply { this.colorId = colorId }
+    fun colorId(colorId: String) = apply { this.colorId = colorId }
 
     /**
      * Builds the [UpdateEventRequest] object.

--- a/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
@@ -94,6 +94,12 @@ data class UpdateEventRequest(
    */
   @Json(name = "notetaker")
   val notetaker: EventNotetakerRequest? = null,
+  /**
+   * The Google color ID for the event. (Currently) Only applies to Google Calendar events.
+   * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
+   */
+  @Json(name = "color_id")
+  val colorId: String? = null,
 ) {
   /**
    * This sealed class represents the different types of event time configurations.
@@ -597,6 +603,7 @@ data class UpdateEventRequest(
     private var capacity: Int? = null
     private var hideParticipant: Boolean? = null
     private var notetaker: EventNotetakerRequest? = null
+    private var colorId: String? = null
 
     /**
      * Set the when object.
@@ -720,6 +727,14 @@ data class UpdateEventRequest(
     fun notetaker(notetaker: EventNotetakerRequest) = apply { this.notetaker = notetaker }
 
     /**
+     * Update the Google color ID for the event. Only applies to Google Calendar events.
+     * @param colorId The Google color ID.
+     * @return The builder.
+     * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
+     */
+    fun colorId(colorId: String) = apply { this.colorId = colorId }
+
+    /**
      * Builds the [UpdateEventRequest] object.
      * @return [UpdateEventRequest] object.
      */
@@ -741,6 +756,7 @@ data class UpdateEventRequest(
         capacity,
         hideParticipant,
         notetaker,
+        colorId,
       )
   }
 }

--- a/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/nylas/models/UpdateEventRequest.kt
@@ -95,7 +95,8 @@ data class UpdateEventRequest(
   @Json(name = "notetaker")
   val notetaker: EventNotetakerRequest? = null,
   /**
-   * The Google color ID for the event. (Currently) Only applies to Google Calendar events.
+   * The Google color ID for the event. Only supported by Google Calendar providers; ignored by other providers.
+   * Valid values are strings "1" through "11".
    * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
    */
   @Json(name = "color_id")
@@ -727,12 +728,13 @@ data class UpdateEventRequest(
     fun notetaker(notetaker: EventNotetakerRequest) = apply { this.notetaker = notetaker }
 
     /**
-     * Update the Google color ID for the event. Only applies to Google Calendar events.
-     * @param colorId The Google color ID.
+     * Update the Google color ID for the event. Only supported by Google Calendar providers; ignored by other providers.
+     * Pass null to clear an existing color. Valid values are strings "1" through "11".
+     * @param colorId The Google color ID, or null to clear the color.
      * @return The builder.
      * @see <a href="https://developers.google.com/calendar/api/v3/reference/colors">Google Calendar Colors</a>
      */
-    fun colorId(colorId: String) = apply { this.colorId = colorId }
+    fun colorId(colorId: String?) = apply { this.colorId = colorId }
 
     /**
      * Builds the [UpdateEventRequest] object.

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -483,15 +483,6 @@ class EventsTests {
     }
 
     @Test
-    fun `UpdateEventRequest builder colorId can be cleared with null`() {
-      val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
-      val request = UpdateEventRequest.Builder().colorId(null).build()
-
-      val json = adapter.toJson(request)
-      assertFalse(json.contains("color_id"))
-    }
-
-    @Test
     fun `Event with existing ConferencingProvider still works properly`() {
       // This test verifies that the original Event model continues to work with the original ConferencingProvider enum
       // The Event model uses the original Conferencing sealed class, not the new CreateEvent/UpdateEvent ones

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -884,12 +884,12 @@ class EventsTests {
       val createEventRequest =
         CreateEventRequest(
           whenObj =
-            CreateEventRequest.When.Timespan(
-              startTime = 1620000000,
-              endTime = 1620000000,
-              startTimezone = "America/Los_Angeles",
-              endTimezone = "America/Los_Angeles",
-            ),
+          CreateEventRequest.When.Timespan(
+            startTime = 1620000000,
+            endTime = 1620000000,
+            startTimezone = "America/Los_Angeles",
+            endTimezone = "America/Los_Angeles",
+          ),
           description = "Description of my new event",
           location = "Los Angeles, CA",
           metadata = mapOf("your-key" to "value"),

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -14,8 +14,10 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
 import java.lang.reflect.Type
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class EventsTests {
   private val mockHttpClient: OkHttpClient = Mockito.mock(OkHttpClient::class.java)
@@ -439,6 +441,54 @@ class EventsTests {
       val details = conferencing["details"] as Map<*, *>
       assertEquals("https://teams.microsoft.com/join/123", details["url"])
       assertEquals("123456", details["pin"])
+    }
+
+    @Test
+    fun `CreateEventRequest with colorId serializes color_id field`() {
+      val adapter = JsonHelper.moshi().adapter(CreateEventRequest::class.java)
+      val request = CreateEventRequest(
+        whenObj = CreateEventRequest.When.Time(1620000000),
+        colorId = "7",
+      )
+
+      val jsonMap = JsonHelper.moshi().adapter(Map::class.java).fromJson(adapter.toJson(request))!!
+      assertEquals("7", jsonMap["color_id"])
+    }
+
+    @Test
+    fun `CreateEventRequest without colorId omits color_id from serialized JSON`() {
+      val adapter = JsonHelper.moshi().adapter(CreateEventRequest::class.java)
+      val request = CreateEventRequest(whenObj = CreateEventRequest.When.Time(1620000000))
+
+      val json = adapter.toJson(request)
+      assertFalse(json.contains("color_id"))
+    }
+
+    @Test
+    fun `UpdateEventRequest with colorId serializes color_id field`() {
+      val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
+      val request = UpdateEventRequest(colorId = "11")
+
+      val jsonMap = JsonHelper.moshi().adapter(Map::class.java).fromJson(adapter.toJson(request))!!
+      assertEquals("11", jsonMap["color_id"])
+    }
+
+    @Test
+    fun `UpdateEventRequest without colorId omits color_id from serialized JSON`() {
+      val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
+      val request = UpdateEventRequest(title = "Test")
+
+      val json = adapter.toJson(request)
+      assertFalse(json.contains("color_id"))
+    }
+
+    @Test
+    fun `UpdateEventRequest builder colorId can be cleared with null`() {
+      val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
+      val request = UpdateEventRequest.Builder().colorId(null).build()
+
+      val json = adapter.toJson(request)
+      assertFalse(json.contains("color_id"))
     }
 
     @Test
@@ -926,6 +976,7 @@ class EventsTests {
       assertEquals("v3/grants/$grantId/events", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Event::class.java), typeCaptor.firstValue)
       assertEquals(adapter.toJson(createEventRequest), requestBodyCaptor.firstValue)
+      assertTrue(requestBodyCaptor.firstValue.contains("\"color_id\":\"7\""))
     }
 
     @Test
@@ -969,6 +1020,7 @@ class EventsTests {
       assertEquals("v3/grants/$grantId/events/$eventId", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Event::class.java), typeCaptor.firstValue)
       assertEquals(adapter.toJson(updateEventRequest), requestBodyCaptor.firstValue)
+      assertTrue(requestBodyCaptor.firstValue.contains("\"color_id\":\"11\""))
     }
 
     @Test

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -111,7 +111,8 @@ class EventsTests {
                 "audio_recording": true,
                 "transcription": true
               }
-            }
+            },
+            "color_id": "7"
           }
           """.trimIndent(),
         )
@@ -171,6 +172,7 @@ class EventsTests {
       assertEquals(false, event.notetaker?.meetingSettings?.videoRecording)
       assertEquals(true, event.notetaker?.meetingSettings?.audioRecording)
       assertEquals(true, event.notetaker?.meetingSettings?.transcription)
+      assertEquals("7", event.colorId)
     }
 
     @Test
@@ -882,12 +884,12 @@ class EventsTests {
       val createEventRequest =
         CreateEventRequest(
           whenObj =
-          CreateEventRequest.When.Timespan(
-            startTime = 1620000000,
-            endTime = 1620000000,
-            startTimezone = "America/Los_Angeles",
-            endTimezone = "America/Los_Angeles",
-          ),
+            CreateEventRequest.When.Timespan(
+              startTime = 1620000000,
+              endTime = 1620000000,
+              startTimezone = "America/Los_Angeles",
+              endTimezone = "America/Los_Angeles",
+            ),
           description = "Description of my new event",
           location = "Los Angeles, CA",
           metadata = mapOf("your-key" to "value"),
@@ -899,6 +901,7 @@ class EventsTests {
               transcription = true,
             ),
           ),
+          colorId = "7",
         )
       val createEventQueryParams =
         CreateEventQueryParams(
@@ -941,6 +944,7 @@ class EventsTests {
               transcription = true,
             ),
           ),
+          colorId = "11",
         )
       val updateEventQueryParams =
         UpdateEventQueryParams(

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -14,8 +14,8 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
 import java.lang.reflect.Type
 import kotlin.test.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 


### PR DESCRIPTION
## Summary
  - Adds `colorId` field to `Event`, `CreateEventRequest`, and `UpdateEventRequest` models, mapped to the `color_id` JSON property
  - Adds `colorId(String)` builder methods on the create/update request builders
  - Currently only applies to Google Calendar events (see [Google Calendar Colors](https://developers.google.com/calendar/api/v3/reference/colors))

## Test plan
  - [x] Updated `EventsTests` to assert `color_id` is deserialized on event fetch
  - [x] Updated create/update event serialization tests to include `colorId`
  - [x] Verify `./gradlew test` passes locally

## License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The license confirmation line is required per Contributing.md and pull_request_template.md since this is a contribution from outside Nylas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional model field and builder setters with test coverage; minimal behavioral change aside from extra JSON property when provided.
> 
> **Overview**
> Adds first-class support for Google Calendar event colors by introducing an optional `colorId` field on `Event`, `CreateEventRequest`, and `UpdateEventRequest`, mapped to the `color_id` JSON property.
> 
> Extends the create/update request builders to set `colorId`, updates the changelog, and expands `EventsTests` to cover `color_id` serialization/deserialization and omission when unset (including clearing via `null` on the update builder).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c267395971494ca4da836b404d9d6ccc59ae012c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->