### PR TITLE
TW-5409: Java Release 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
+## [v2.17.0] - Release 2026-06-15
 
 ### Added
 * Application administration updates

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ This repository is for contributors and anyone installing the SDK from source. I
 Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.nylas.sdk:nylas:2.16.1")
+implementation("com.nylas.sdk:nylas:2.17.0")
 ```
 
 Groovy (`build.gradle`):
 
 ```groovy
-implementation 'com.nylas.sdk:nylas:2.16.1'
+implementation 'com.nylas.sdk:nylas:2.17.0'
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation 'com.nylas.sdk:nylas:2.16.1'
 <dependency>
   <groupId>com.nylas.sdk</groupId>
   <artifactId>nylas</artifactId>
-  <version>2.16.1</version>
+  <version>2.17.0</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.16.1
+version=2.17.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
## [v2.17.0] - Release 2026-06-15

### Added
* Application administration updates
  - `Applications.update()` for `PATCH /v3/applications`
  - Application updates support sparse branding fields and `callback_uris`, including callback URI IDs for preserving existing callback URIs
  - Redirect URI updates use `PATCH /v3/applications/redirect-uris/{id}`
  - Manage Domains admin CRUD and verification endpoints on `client.domains()` via `/v3/admin/domains`; these support `ServiceAccountSigner` for Nylas Service Account request-signing auth without Bearer auth, canonical signed wire bodies, manually signed headers in `RequestOverrides.headers`, base64-encoded PEM service-account keys, and request-only verification types
  - `Workspaces` resource via `client.workspaces()`: CRUD, paginated listing with `limit` and `page_token`, `autoGroup`, `manualAssign`, `default`, `policyId`, explicit `clearPolicyId`, and `ruleIds`; `CreateWorkspaceRequest` validates that `domain` is present when `autoGroup` is true; `WorkspaceAutoGroupRequest.invalidAlso` includes invalid grants in auto-grouping when enabled
* Transactional email support via `Domains.sendTransactionalEmail()`
  - `SendTransactionalEmailRequest` model (and fluent `Builder`) for composing transactional messages from a verified domain — supports `to`, `from`, `cc`, `bcc`, `reply_to`, `subject`, `body`, `send_at`, `reply_to_message_id`, `tracking_options`, `use_draft`, `custom_headers`, and `is_plaintext`
  - `NylasClient.domains()` accessor returning the new `Domains` resource
  - Automatic multipart/form-data upload when the total attachment size exceeds the JSON limit
  - Examples: `TransactionalEmailExample.java` and `KotlinTransactionalEmailExample.kt`
* Administration API — Policies, Rules, and Lists (app-level, `nylas` provider only)
  - `Policies` resource via `client.policies()`: full CRUD (`list`, `find`, `create`, `update`, `destroy`) with `CreatePolicyRequest` / `UpdatePolicyRequest` and supporting models (`Policy`, `PolicyLimits`, `PolicyOptions`, `PolicySpamDetection`)
  - `Rules` resource via `client.rules()`: full CRUD plus `listEvaluations` for grant rule-evaluation audit records; handles the nested `/v3/rules` list envelope returned by the API
  - `NylasLists` resource via `client.lists()`: full CRUD plus `listItems`, `addItems`, and `removeItems` for managing list contents; `NylasList`, `NylasListItem`, `NylasListType`, `ListItemsRequest` models
  - `NylasLists.create()` for `POST /v3/lists` with `CreateNylasListRequest` (`name`, `type`, and optional `description`)

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.