### PR TITLE
fix(http): use addEncodedPathSegments to stop double-encoding path ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## [unreleased]
+
+### Fixed
+* Prevent double-encoding of pre-encoded path IDs when building request URLs, fixing Gmail attachment download 404s for attachment IDs containing reserved characters such as `:` and `=`
+
 ## [v2.17.0] - Release 2026-06-15
 
 ### Added

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -528,12 +528,14 @@ open class NylasClient(
 
   private fun buildUrl(path: String, queryParams: IQueryParams?, overrides: RequestOverrides?): HttpUrl.Builder {
     // Sets the API URI if it is provided in the overrides.
+    // Path segments are already percent-encoded by the resource layer (see PathEncoder).
+    // Use addEncodedPathSegments so OkHttp does not encode them a second time
+    // (e.g. turning an already-encoded ':' of "%3A" into "%253A").
     var url = if (overrides?.apiUri != null) {
-      overrides.apiUri.toHttpUrl().newBuilder().addPathSegments(path)
+      overrides.apiUri.toHttpUrl().newBuilder().addEncodedPathSegments(path)
     } else {
-      newUrlBuilder().addPathSegments(path)
+      newUrlBuilder().addEncodedPathSegments(path)
     }
-
     if (queryParams != null) {
       url = addQueryParams(url, queryParams.convertToMap())
     }

--- a/src/main/kotlin/com/nylas/NylasClient.kt
+++ b/src/main/kotlin/com/nylas/NylasClient.kt
@@ -215,7 +215,18 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    return executeRequest(url, HttpMethod.GET, null, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executeGetEncoded(
+    path: String,
+    resultType: Type,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     return executeRequest(url, HttpMethod.GET, null, resultType, overrides)
   }
 
@@ -236,7 +247,20 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    val jsonBody = if (requestBody != null) JsonHelper.jsonRequestBody(requestBody) else null
+    return executeRequest(url, HttpMethod.PUT, jsonBody, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executePutEncoded(
+    path: String,
+    resultType: Type,
+    requestBody: String? = null,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     val jsonBody = if (requestBody != null) JsonHelper.jsonRequestBody(requestBody) else null
     return executeRequest(url, HttpMethod.PUT, jsonBody, resultType, overrides)
   }
@@ -258,7 +282,20 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    val jsonBody = if (requestBody != null) JsonHelper.jsonRequestBody(requestBody) else null
+    return executeRequest(url, HttpMethod.PATCH, jsonBody, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executePatchEncoded(
+    path: String,
+    resultType: Type,
+    requestBody: String? = null,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     val jsonBody = if (requestBody != null) JsonHelper.jsonRequestBody(requestBody) else null
     return executeRequest(url, HttpMethod.PATCH, jsonBody, resultType, overrides)
   }
@@ -280,7 +317,23 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    var jsonBody = ByteArray(0).toRequestBody(null)
+    if (requestBody != null) {
+      jsonBody = JsonHelper.jsonRequestBody(requestBody)
+    }
+    return executeRequest(url, HttpMethod.POST, jsonBody, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executePostEncoded(
+    path: String,
+    resultType: Type,
+    requestBody: String? = null,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     var jsonBody = ByteArray(0).toRequestBody(null)
     if (requestBody != null) {
       jsonBody = JsonHelper.jsonRequestBody(requestBody)
@@ -303,7 +356,18 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    return executeRequest(url, HttpMethod.DELETE, null, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executeDeleteEncoded(
+    path: String,
+    resultType: Type,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     return executeRequest(url, HttpMethod.DELETE, null, resultType, overrides)
   }
 
@@ -324,7 +388,20 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    val jsonBody = JsonHelper.jsonRequestBody(requestBody)
+    return executeRequest(url, HttpMethod.DELETE, jsonBody, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executeDeleteEncoded(
+    path: String,
+    resultType: Type,
+    requestBody: String,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     val jsonBody = JsonHelper.jsonRequestBody(requestBody)
     return executeRequest(url, HttpMethod.DELETE, jsonBody, resultType, overrides)
   }
@@ -348,7 +425,20 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): T {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    return executeRequest(url, method, requestBody, resultType, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun <T> executeFormRequestEncoded(
+    path: String,
+    method: HttpMethod,
+    requestBody: RequestBody,
+    resultType: Type,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): T {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     return executeRequest(url, method, requestBody, resultType, overrides)
   }
 
@@ -406,7 +496,17 @@ open class NylasClient(
     queryParams: IQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): ResponseBody {
-    val url = buildUrl(path, queryParams, overrides)
+    val url = buildRawUrl(path, queryParams, overrides)
+    return this.executeRequestRawResponse(url, HttpMethod.GET, null, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  internal open fun downloadResponseEncoded(
+    path: String,
+    queryParams: IQueryParams? = null,
+    overrides: RequestOverrides? = null,
+  ): ResponseBody {
+    val url = buildEncodedUrl(path, queryParams, overrides)
     return this.executeRequestRawResponse(url, HttpMethod.GET, null, overrides)
   }
 
@@ -526,11 +626,20 @@ open class NylasClient(
     )
   }
 
-  private fun buildUrl(path: String, queryParams: IQueryParams?, overrides: RequestOverrides?): HttpUrl.Builder {
-    // Sets the API URI if it is provided in the overrides.
-    // Path segments are already percent-encoded by the resource layer (see PathEncoder).
-    // Use addEncodedPathSegments so OkHttp does not encode them a second time
-    // (e.g. turning an already-encoded ':' of "%3A" into "%253A").
+  private fun buildRawUrl(path: String, queryParams: IQueryParams?, overrides: RequestOverrides?): HttpUrl.Builder {
+    var url = if (overrides?.apiUri != null) {
+      overrides.apiUri.toHttpUrl().newBuilder().addPathSegments(path)
+    } else {
+      newUrlBuilder().addPathSegments(path)
+    }
+    if (queryParams != null) {
+      url = addQueryParams(url, queryParams.convertToMap())
+    }
+
+    return url
+  }
+
+  private fun buildEncodedUrl(path: String, queryParams: IQueryParams?, overrides: RequestOverrides?): HttpUrl.Builder {
     var url = if (overrides?.apiUri != null) {
       overrides.apiUri.toHttpUrl().newBuilder().addEncodedPathSegments(path)
     } else {

--- a/src/main/kotlin/com/nylas/resources/Attachments.kt
+++ b/src/main/kotlin/com/nylas/resources/Attachments.kt
@@ -25,7 +25,7 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
   @JvmOverloads
   fun find(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): Response<Attachment> {
     val path = String.format("v3/grants/%s/attachments/%s", identifier, PathEncoder.encode(attachmentId))
-    return findResource(path, queryParams, overrides = overrides)
+    return findResourceEncoded(path, queryParams, overrides = overrides)
   }
 
   /**
@@ -48,7 +48,7 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
   fun download(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): ResponseBody {
     val path = String.format("v3/grants/%s/attachments/%s/download", identifier, PathEncoder.encode(attachmentId))
 
-    return client.downloadResponse(path, queryParams, overrides = overrides)
+    return client.downloadResponseEncoded(path, queryParams, overrides = overrides)
   }
 
   /**

--- a/src/main/kotlin/com/nylas/resources/Attachments.kt
+++ b/src/main/kotlin/com/nylas/resources/Attachments.kt
@@ -24,7 +24,7 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): Response<Attachment> {
-    val path = String.format("v3/grants/%s/attachments/%s", identifier, PathEncoder.encode(attachmentId))
+    val path = String.format("v3/grants/%s/attachments/%s", PathEncoder.encode(identifier), PathEncoder.encode(attachmentId))
     return findResourceEncoded(path, queryParams, overrides = overrides)
   }
 
@@ -46,7 +46,7 @@ class Attachments(client: NylasClient) : Resource<Attachment>(client, Attachment
   @Throws(NylasOAuthError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun download(identifier: String, attachmentId: String, queryParams: FindAttachmentQueryParams, overrides: RequestOverrides? = null): ResponseBody {
-    val path = String.format("v3/grants/%s/attachments/%s/download", identifier, PathEncoder.encode(attachmentId))
+    val path = String.format("v3/grants/%s/attachments/%s/download", PathEncoder.encode(identifier), PathEncoder.encode(attachmentId))
 
     return client.downloadResponseEncoded(path, queryParams, overrides = overrides)
   }

--- a/src/main/kotlin/com/nylas/resources/Bookings.kt
+++ b/src/main/kotlin/com/nylas/resources/Bookings.kt
@@ -27,7 +27,7 @@ class Bookings(client: NylasClient) : Resource<Booking>(client, Booking::class.j
     overrides: RequestOverrides? = null,
   ): Response<Booking> {
     val path = String.format("v3/scheduling/bookings/%s", PathEncoder.encode(bookingId))
-    return findResource(path, queryParams, overrides = overrides)
+    return findResourceEncoded(path, queryParams, overrides = overrides)
   }
 
   /**
@@ -47,7 +47,7 @@ class Bookings(client: NylasClient) : Resource<Booking>(client, Booking::class.j
     val path = "v3/scheduling/bookings"
     val adapter = JsonHelper.moshi().adapter(CreateBookingRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, queryParams, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, queryParams, overrides = overrides)
   }
 
   /**
@@ -69,7 +69,7 @@ class Bookings(client: NylasClient) : Resource<Booking>(client, Booking::class.j
     val path = String.format("v3/scheduling/bookings/%s", PathEncoder.encode(bookingId))
     val adapter = JsonHelper.moshi().adapter(ConfirmBookingRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, queryParams, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, queryParams, overrides = overrides)
   }
 
   /**
@@ -91,7 +91,7 @@ class Bookings(client: NylasClient) : Resource<Booking>(client, Booking::class.j
     val path = String.format("v3/scheduling/bookings/%s", PathEncoder.encode(bookingId))
     val adapter = JsonHelper.moshi().adapter(RescheduleBookingRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return patchResource(path, serializedRequestBody, queryParams, overrides = overrides)
+    return patchResourceEncoded(path, serializedRequestBody, queryParams, overrides = overrides)
   }
 
   /**
@@ -136,7 +136,7 @@ class Bookings(client: NylasClient) : Resource<Booking>(client, Booking::class.j
     val path = String.format("v3/scheduling/bookings/%s", PathEncoder.encode(bookingId))
     val adapter = JsonHelper.moshi().adapter(DestroyBookingRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return client.executeDelete(path, DeleteResponse::class.java, serializedRequestBody, queryParams, overrides)
+    return client.executeDeleteEncoded(path, DeleteResponse::class.java, serializedRequestBody, queryParams, overrides)
   }
 
   /**
@@ -153,6 +153,6 @@ class Bookings(client: NylasClient) : Resource<Booking>(client, Booking::class.j
    */
   fun destroy(bookingId: String, queryParams: DestroyBookingQueryParams? = null, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/scheduling/bookings/%s", PathEncoder.encode(bookingId))
-    return destroyResource(path, queryParams, overrides = overrides)
+    return destroyResourceEncoded(path, queryParams, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Calendars.kt
+++ b/src/main/kotlin/com/nylas/resources/Calendars.kt
@@ -27,7 +27,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @JvmOverloads
   fun list(identifier: String, queryParams: ListCalendersQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Calendar> {
     val path = String.format("v3/grants/%s/calendars", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -41,7 +41,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @JvmOverloads
   fun find(identifier: String, calendarId: String, overrides: RequestOverrides? = null): Response<Calendar> {
     val path = String.format("v3/grants/%s/calendars/%s", identifier, PathEncoder.encode(calendarId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -57,7 +57,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
     val path = String.format("v3/grants/%s/calendars", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateCalendarRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -74,7 +74,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
     val path = String.format("v3/grants/%s/calendars/%s", identifier, PathEncoder.encode(calendarId))
     val adapter = JsonHelper.moshi().adapter(UpdateCalendarRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -87,7 +87,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   fun destroy(identifier: String, calendarId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/calendars/%s", identifier, PathEncoder.encode(calendarId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -107,7 +107,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
 
     val responseType = Types.newParameterizedType(Response::class.java, GetAvailabilityResponse::class.java)
 
-    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -128,6 +128,6 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
 
     val responseType = Types.newParameterizedType(Response::class.java, GET_FREE_BUSY_RESPONSE_ADAPTER)
 
-    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Calendars.kt
+++ b/src/main/kotlin/com/nylas/resources/Calendars.kt
@@ -26,7 +26,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListCalendersQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Calendar> {
-    val path = String.format("v3/grants/%s/calendars", identifier)
+    val path = String.format("v3/grants/%s/calendars", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -40,7 +40,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, calendarId: String, overrides: RequestOverrides? = null): Response<Calendar> {
-    val path = String.format("v3/grants/%s/calendars/%s", identifier, PathEncoder.encode(calendarId))
+    val path = String.format("v3/grants/%s/calendars/%s", PathEncoder.encode(identifier), PathEncoder.encode(calendarId))
     return findResourceEncoded(path, overrides = overrides)
   }
 
@@ -54,7 +54,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun create(identifier: String, requestBody: CreateCalendarRequest, overrides: RequestOverrides? = null): Response<Calendar> {
-    val path = String.format("v3/grants/%s/calendars", identifier)
+    val path = String.format("v3/grants/%s/calendars", PathEncoder.encode(identifier))
     val adapter = JsonHelper.moshi().adapter(CreateCalendarRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -71,7 +71,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, calendarId: String, requestBody: UpdateCalendarRequest, overrides: RequestOverrides? = null): Response<Calendar> {
-    val path = String.format("v3/grants/%s/calendars/%s", identifier, PathEncoder.encode(calendarId))
+    val path = String.format("v3/grants/%s/calendars/%s", PathEncoder.encode(identifier), PathEncoder.encode(calendarId))
     val adapter = JsonHelper.moshi().adapter(UpdateCalendarRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -86,7 +86,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   fun destroy(identifier: String, calendarId: String, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/calendars/%s", identifier, PathEncoder.encode(calendarId))
+    val path = String.format("v3/grants/%s/calendars/%s", PathEncoder.encode(identifier), PathEncoder.encode(calendarId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 
@@ -120,7 +120,7 @@ class Calendars(client: NylasClient) : Resource<Calendar>(client, Calendar::clas
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun getFreeBusy(identifier: String, request: GetFreeBusyRequest, overrides: RequestOverrides? = null): Response<List<GetFreeBusyResponse>> {
-    val path = String.format("v3/grants/%s/calendars/free-busy", identifier)
+    val path = String.format("v3/grants/%s/calendars/free-busy", PathEncoder.encode(identifier))
 
     val serializedRequestBody = JsonHelper.moshi()
       .adapter(GetFreeBusyRequest::class.java)

--- a/src/main/kotlin/com/nylas/resources/Configurations.kt
+++ b/src/main/kotlin/com/nylas/resources/Configurations.kt
@@ -33,7 +33,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     overrides: RequestOverrides? = null,
   ): ListResponse<Configuration> {
     val path = String.format("v3/grants/%s/scheduling/configurations", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -51,7 +51,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     overrides: RequestOverrides? = null,
   ): Response<Configuration> {
     val path = String.format("v3/grants/%s/scheduling/configurations/%s", identifier, PathEncoder.encode(configId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -71,7 +71,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     val path = String.format("v3/grants/%s/scheduling/configurations", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateConfigurationRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -93,7 +93,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     val path = String.format("v3/grants/%s/scheduling/configurations/%s", identifier, PathEncoder.encode(configId))
     val adapter = JsonHelper.moshi().adapter(UpdateConfigurationRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -110,6 +110,6 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     overrides: RequestOverrides? = null,
   ): DeleteResponse {
     val path = String.format("v3/grants/%s/scheduling/configurations/%s", identifier, PathEncoder.encode(configId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Configurations.kt
+++ b/src/main/kotlin/com/nylas/resources/Configurations.kt
@@ -32,7 +32,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     queryParams: ListConfigurationsQueryParams? = null,
     overrides: RequestOverrides? = null,
   ): ListResponse<Configuration> {
-    val path = String.format("v3/grants/%s/scheduling/configurations", identifier)
+    val path = String.format("v3/grants/%s/scheduling/configurations", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -50,7 +50,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     configId: String,
     overrides: RequestOverrides? = null,
   ): Response<Configuration> {
-    val path = String.format("v3/grants/%s/scheduling/configurations/%s", identifier, PathEncoder.encode(configId))
+    val path = String.format("v3/grants/%s/scheduling/configurations/%s", PathEncoder.encode(identifier), PathEncoder.encode(configId))
     return findResourceEncoded(path, overrides = overrides)
   }
 
@@ -68,7 +68,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     requestBody: CreateConfigurationRequest,
     overrides: RequestOverrides? = null,
   ): Response<Configuration> {
-    val path = String.format("v3/grants/%s/scheduling/configurations", identifier)
+    val path = String.format("v3/grants/%s/scheduling/configurations", PathEncoder.encode(identifier))
     val adapter = JsonHelper.moshi().adapter(CreateConfigurationRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -90,7 +90,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     requestBody: UpdateConfigurationRequest,
     overrides: RequestOverrides? = null,
   ): Response<Configuration> {
-    val path = String.format("v3/grants/%s/scheduling/configurations/%s", identifier, PathEncoder.encode(configId))
+    val path = String.format("v3/grants/%s/scheduling/configurations/%s", PathEncoder.encode(identifier), PathEncoder.encode(configId))
     val adapter = JsonHelper.moshi().adapter(UpdateConfigurationRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -109,7 +109,7 @@ class Configurations(client: NylasClient) : Resource<Configuration>(client, Conf
     configId: String,
     overrides: RequestOverrides? = null,
   ): DeleteResponse {
-    val path = String.format("v3/grants/%s/scheduling/configurations/%s", identifier, PathEncoder.encode(configId))
+    val path = String.format("v3/grants/%s/scheduling/configurations/%s", PathEncoder.encode(identifier), PathEncoder.encode(configId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Contacts.kt
+++ b/src/main/kotlin/com/nylas/resources/Contacts.kt
@@ -18,7 +18,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @JvmOverloads
   fun list(identifier: String, queryParams: ListContactsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Contact> {
     val path = String.format("v3/grants/%s/contacts", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -33,7 +33,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @JvmOverloads
   fun find(identifier: String, contactId: String, queryParams: FindContactQueryParams? = null, overrides: RequestOverrides? = null): Response<Contact> {
     val path = String.format("v3/grants/%s/contacts/%s", identifier, PathEncoder.encode(contactId))
-    return findResource(path, queryParams, overrides)
+    return findResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -49,7 +49,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
     val path = String.format("v3/grants/%s/contacts", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateContactRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -66,7 +66,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
     val path = String.format("v3/grants/%s/contacts/%s", identifier, PathEncoder.encode(contactId))
     val adapter = JsonHelper.moshi().adapter(UpdateContactRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -80,7 +80,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @JvmOverloads
   fun destroy(identifier: String, contactId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/contacts/%s", identifier, PathEncoder.encode(contactId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -95,6 +95,6 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   fun listGroups(identifier: String, queryParams: ListContactGroupsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<ContactGroup> {
     val path = String.format("v3/grants/%s/contacts/groups", identifier)
     val responseType = Types.newParameterizedType(ListResponse::class.java, ContactGroup::class.java)
-    return client.executeGet(path, responseType, queryParams, overrides)
+    return client.executeGetEncoded(path, responseType, queryParams, overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Contacts.kt
+++ b/src/main/kotlin/com/nylas/resources/Contacts.kt
@@ -17,7 +17,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListContactsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Contact> {
-    val path = String.format("v3/grants/%s/contacts", identifier)
+    val path = String.format("v3/grants/%s/contacts", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -32,7 +32,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, contactId: String, queryParams: FindContactQueryParams? = null, overrides: RequestOverrides? = null): Response<Contact> {
-    val path = String.format("v3/grants/%s/contacts/%s", identifier, PathEncoder.encode(contactId))
+    val path = String.format("v3/grants/%s/contacts/%s", PathEncoder.encode(identifier), PathEncoder.encode(contactId))
     return findResourceEncoded(path, queryParams, overrides)
   }
 
@@ -46,7 +46,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun create(identifier: String, requestBody: CreateContactRequest, overrides: RequestOverrides? = null): Response<Contact> {
-    val path = String.format("v3/grants/%s/contacts", identifier)
+    val path = String.format("v3/grants/%s/contacts", PathEncoder.encode(identifier))
     val adapter = JsonHelper.moshi().adapter(CreateContactRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -63,7 +63,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, contactId: String, requestBody: UpdateContactRequest, overrides: RequestOverrides? = null): Response<Contact> {
-    val path = String.format("v3/grants/%s/contacts/%s", identifier, PathEncoder.encode(contactId))
+    val path = String.format("v3/grants/%s/contacts/%s", PathEncoder.encode(identifier), PathEncoder.encode(contactId))
     val adapter = JsonHelper.moshi().adapter(UpdateContactRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -79,7 +79,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun destroy(identifier: String, contactId: String, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/contacts/%s", identifier, PathEncoder.encode(contactId))
+    val path = String.format("v3/grants/%s/contacts/%s", PathEncoder.encode(identifier), PathEncoder.encode(contactId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 
@@ -93,7 +93,7 @@ class Contacts(client: NylasClient) : Resource<Contact>(client, Contact::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun listGroups(identifier: String, queryParams: ListContactGroupsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<ContactGroup> {
-    val path = String.format("v3/grants/%s/contacts/groups", identifier)
+    val path = String.format("v3/grants/%s/contacts/groups", PathEncoder.encode(identifier))
     val responseType = Types.newParameterizedType(ListResponse::class.java, ContactGroup::class.java)
     return client.executeGetEncoded(path, responseType, queryParams, overrides)
   }

--- a/src/main/kotlin/com/nylas/resources/Credentials.kt
+++ b/src/main/kotlin/com/nylas/resources/Credentials.kt
@@ -17,7 +17,7 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
   @JvmOverloads
   fun list(provider: AuthProvider, queryParams: ListCredentialsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Credential> {
     val path = String.format("v3/connectors/%s/creds", provider.value)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -31,7 +31,7 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
   @JvmOverloads
   fun find(provider: AuthProvider, credentialsId: String, overrides: RequestOverrides? = null): Response<Credential> {
     val path = String.format("v3/connectors/%s/creds/%s", provider.value, PathEncoder.encode(credentialsId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -49,7 +49,7 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
       .adapter(CreateCredentialRequest::class.java)
       .toJson(requestBody)
 
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -68,7 +68,7 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
       .adapter(UpdateCredentialRequest::class.java)
       .toJson(requestBody)
 
-    return patchResource(path, serializedRequestBody, overrides = overrides)
+    return patchResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -82,6 +82,6 @@ class Credentials(client: NylasClient) : Resource<Credential>(client, Credential
   @JvmOverloads
   fun destroy(provider: AuthProvider, credentialsId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/connectors/%s/creds/%s", provider.value, PathEncoder.encode(credentialsId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Domains.kt
+++ b/src/main/kotlin/com/nylas/resources/Domains.kt
@@ -62,10 +62,10 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
       val attachmentLessPayload = requestBody.copy(attachments = null)
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
-      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
+      client.executeFormRequestEncoded(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      createResource(path, serializedRequestBody, overrides = overrides)
+      createResourceEncoded(path, serializedRequestBody, overrides = overrides)
     }
   }
 
@@ -101,7 +101,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
   fun list(queryParams: ListDomainsQueryParams? = null, overrides: RequestOverrides): ListResponse<Domain> {
     val signedOverrides = requireServiceAccountSigning(overrides)
     val responseType = Types.newParameterizedType(ListResponse::class.java, Domain::class.java)
-    return client.executeGet("v3/admin/domains", responseType, queryParams, signedOverrides)
+    return client.executeGetEncoded("v3/admin/domains", responseType, queryParams, signedOverrides)
   }
 
   /**
@@ -120,7 +120,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
   ): ListResponse<Domain> {
     val (signedOverrides) = signedRequest(NylasClient.HttpMethod.GET, "v3/admin/domains", signer, overrides = overrides)
     val responseType = Types.newParameterizedType(ListResponse::class.java, Domain::class.java)
-    return client.executeGet("v3/admin/domains", responseType, queryParams, signedOverrides)
+    return client.executeGetEncoded("v3/admin/domains", responseType, queryParams, signedOverrides)
   }
 
   /**
@@ -134,7 +134,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val signedOverrides = requireServiceAccountSigning(overrides)
     val path = String.format("v3/admin/domains/%s", PathEncoder.encode(domainId))
     val responseType = Types.newParameterizedType(Response::class.java, Domain::class.java)
-    return client.executeGet(path, responseType, overrides = signedOverrides)
+    return client.executeGetEncoded(path, responseType, overrides = signedOverrides)
   }
 
   /**
@@ -150,7 +150,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s", PathEncoder.encode(domainId))
     val (signedOverrides) = signedRequest(NylasClient.HttpMethod.GET, path, signer, overrides = overrides)
     val responseType = Types.newParameterizedType(Response::class.java, Domain::class.java)
-    return client.executeGet(path, responseType, overrides = signedOverrides)
+    return client.executeGetEncoded(path, responseType, overrides = signedOverrides)
   }
 
   /**
@@ -165,7 +165,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = "v3/admin/domains"
     val responseType = Types.newParameterizedType(Response::class.java, Domain::class.java)
     val serializedRequestBody = ServiceAccountSigner.canonicalJson(requestBody)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -185,7 +185,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = "v3/admin/domains"
     val (signedOverrides, serializedRequestBody) = signedRequest(NylasClient.HttpMethod.POST, path, signer, requestBody, overrides)
     val responseType = Types.newParameterizedType(Response::class.java, Domain::class.java)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -201,7 +201,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s", PathEncoder.encode(domainId))
     val responseType = Types.newParameterizedType(Response::class.java, Domain::class.java)
     val serializedRequestBody = ServiceAccountSigner.canonicalJson(requestBody)
-    return client.executePut(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePutEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -223,7 +223,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s", PathEncoder.encode(domainId))
     val (signedOverrides, serializedRequestBody) = signedRequest(NylasClient.HttpMethod.PUT, path, signer, requestBody, overrides)
     val responseType = Types.newParameterizedType(Response::class.java, Domain::class.java)
-    return client.executePut(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePutEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -236,7 +236,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
   fun destroy(domainId: String, overrides: RequestOverrides): DeleteResponse {
     val signedOverrides = requireServiceAccountSigning(overrides)
     val path = String.format("v3/admin/domains/%s", PathEncoder.encode(domainId))
-    return client.executeDelete(path, DeleteResponse::class.java, overrides = signedOverrides)
+    return client.executeDeleteEncoded(path, DeleteResponse::class.java, overrides = signedOverrides)
   }
 
   /**
@@ -251,7 +251,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
   fun destroy(domainId: String, signer: ServiceAccountSigner, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/admin/domains/%s", PathEncoder.encode(domainId))
     val (signedOverrides) = signedRequest(NylasClient.HttpMethod.DELETE, path, signer, overrides = overrides)
-    return client.executeDelete(path, DeleteResponse::class.java, overrides = signedOverrides)
+    return client.executeDeleteEncoded(path, DeleteResponse::class.java, overrides = signedOverrides)
   }
 
   /**
@@ -271,7 +271,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s/info", PathEncoder.encode(domainId))
     val responseType = Types.newParameterizedType(Response::class.java, DomainVerificationResult::class.java)
     val serializedRequestBody = ServiceAccountSigner.canonicalJson(requestBody)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -293,7 +293,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s/info", PathEncoder.encode(domainId))
     val (signedOverrides, serializedRequestBody) = signedRequest(NylasClient.HttpMethod.POST, path, signer, requestBody, overrides)
     val responseType = Types.newParameterizedType(Response::class.java, DomainVerificationResult::class.java)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -313,7 +313,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s/verify", PathEncoder.encode(domainId))
     val responseType = Types.newParameterizedType(Response::class.java, DomainVerificationResult::class.java)
     val serializedRequestBody = ServiceAccountSigner.canonicalJson(requestBody)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   /**
@@ -335,7 +335,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     val path = String.format("v3/admin/domains/%s/verify", PathEncoder.encode(domainId))
     val (signedOverrides, serializedRequestBody) = signedRequest(NylasClient.HttpMethod.POST, path, signer, requestBody, overrides)
     val responseType = Types.newParameterizedType(Response::class.java, DomainVerificationResult::class.java)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = signedOverrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = signedOverrides)
   }
 
   companion object {

--- a/src/main/kotlin/com/nylas/resources/Domains.kt
+++ b/src/main/kotlin/com/nylas/resources/Domains.kt
@@ -53,7 +53,7 @@ class Domains(client: NylasClient) : Resource<Message>(client, Message::class.ja
     requestBody: SendTransactionalEmailRequest,
     overrides: RequestOverrides? = null,
   ): Response<Message> {
-    val path = String.format("v3/domains/%s/messages/send", domainName)
+    val path = String.format("v3/domains/%s/messages/send", PathEncoder.encode(domainName))
     val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
     val adapter = JsonHelper.moshi().adapter(SendTransactionalEmailRequest::class.java)
 

--- a/src/main/kotlin/com/nylas/resources/Drafts.kt
+++ b/src/main/kotlin/com/nylas/resources/Drafts.kt
@@ -18,7 +18,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListDraftsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Draft> {
-    val path = String.format("v3/grants/%s/drafts", identifier)
+    val path = String.format("v3/grants/%s/drafts", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -32,7 +32,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, draftId: String, overrides: RequestOverrides? = null): Response<Draft> {
-    val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
+    val path = String.format("v3/grants/%s/drafts/%s", PathEncoder.encode(identifier), PathEncoder.encode(draftId))
     return findResourceEncoded(path, overrides = overrides)
   }
 
@@ -46,7 +46,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun create(identifier: String, requestBody: CreateDraftRequest, overrides: RequestOverrides? = null): Response<Draft> {
-    val path = String.format("v3/grants/%s/drafts", identifier)
+    val path = String.format("v3/grants/%s/drafts", PathEncoder.encode(identifier))
     val responseType = Types.newParameterizedType(Response::class.java, Draft::class.java)
     val adapter = JsonHelper.moshi().adapter(CreateDraftRequest::class.java)
 
@@ -76,7 +76,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, draftId: String, requestBody: UpdateDraftRequest, overrides: RequestOverrides? = null): Response<Draft> {
-    val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
+    val path = String.format("v3/grants/%s/drafts/%s", PathEncoder.encode(identifier), PathEncoder.encode(draftId))
     val responseType = Types.newParameterizedType(Response::class.java, Draft::class.java)
     val adapter = JsonHelper.moshi().adapter(UpdateDraftRequest::class.java)
 
@@ -105,7 +105,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun destroy(identifier: String, draftId: String, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
+    val path = String.format("v3/grants/%s/drafts/%s", PathEncoder.encode(identifier), PathEncoder.encode(draftId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 
@@ -119,7 +119,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun send(identifier: String, draftId: String, overrides: RequestOverrides? = null): Response<Message> {
-    val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
+    val path = String.format("v3/grants/%s/drafts/%s", PathEncoder.encode(identifier), PathEncoder.encode(draftId))
     val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
     return client.executePostEncoded(path, responseType, overrides = overrides)
   }

--- a/src/main/kotlin/com/nylas/resources/Drafts.kt
+++ b/src/main/kotlin/com/nylas/resources/Drafts.kt
@@ -19,7 +19,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @JvmOverloads
   fun list(identifier: String, queryParams: ListDraftsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Draft> {
     val path = String.format("v3/grants/%s/drafts", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -33,7 +33,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @JvmOverloads
   fun find(identifier: String, draftId: String, overrides: RequestOverrides? = null): Response<Draft> {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -58,10 +58,10 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
 
-      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
+      client.executeFormRequestEncoded(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      createResource(path, serializedRequestBody, overrides = overrides)
+      createResourceEncoded(path, serializedRequestBody, overrides = overrides)
     }
   }
 
@@ -88,10 +88,10 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
 
-      client.executeFormRequest(path, NylasClient.HttpMethod.PUT, multipart, responseType, overrides = overrides)
+      client.executeFormRequestEncoded(path, NylasClient.HttpMethod.PUT, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      updateResource(path, serializedRequestBody, overrides = overrides)
+      updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
     }
   }
 
@@ -106,7 +106,7 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   @JvmOverloads
   fun destroy(identifier: String, draftId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -121,6 +121,6 @@ class Drafts(client: NylasClient) : Resource<Draft>(client, Draft::class.java) {
   fun send(identifier: String, draftId: String, overrides: RequestOverrides? = null): Response<Message> {
     val path = String.format("v3/grants/%s/drafts/%s", identifier, PathEncoder.encode(draftId))
     val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
-    return client.executePost(path, responseType, overrides = overrides)
+    return client.executePostEncoded(path, responseType, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Events.kt
+++ b/src/main/kotlin/com/nylas/resources/Events.kt
@@ -23,7 +23,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListEventQueryParams, overrides: RequestOverrides? = null): ListResponse<Event> {
-    val path = String.format("v3/grants/%s/events", identifier)
+    val path = String.format("v3/grants/%s/events", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -40,7 +40,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun listImportEvents(identifier: String, queryParams: ListImportEventQueryParams, overrides: RequestOverrides? = null): ListResponse<Event> {
-    val path = String.format("v3/grants/%s/events/import", identifier)
+    val path = String.format("v3/grants/%s/events/import", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -55,7 +55,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, eventId: String, queryParams: FindEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
-    val path = String.format("v3/grants/%s/events/%s", identifier, PathEncoder.encode(eventId))
+    val path = String.format("v3/grants/%s/events/%s", PathEncoder.encode(identifier), PathEncoder.encode(eventId))
     return findResourceEncoded(path, queryParams, overrides)
   }
 
@@ -70,7 +70,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun create(identifier: String, requestBody: CreateEventRequest, queryParams: CreateEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
-    val path = String.format("v3/grants/%s/events", identifier)
+    val path = String.format("v3/grants/%s/events", PathEncoder.encode(identifier))
     val adapter = JsonHelper.moshi().adapter(CreateEventRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return createResourceEncoded(path, serializedRequestBody, queryParams, overrides)
@@ -88,7 +88,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, eventId: String, requestBody: UpdateEventRequest, queryParams: UpdateEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
-    val path = String.format("v3/grants/%s/events/%s", identifier, PathEncoder.encode(eventId))
+    val path = String.format("v3/grants/%s/events/%s", PathEncoder.encode(identifier), PathEncoder.encode(eventId))
     val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, queryParams, overrides)
@@ -105,7 +105,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun destroy(identifier: String, eventId: String, queryParams: DestroyEventQueryParams, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/events/%s", identifier, PathEncoder.encode(eventId))
+    val path = String.format("v3/grants/%s/events/%s", PathEncoder.encode(identifier), PathEncoder.encode(eventId))
     return destroyResourceEncoded(path, queryParams, overrides)
   }
 
@@ -121,7 +121,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun sendRsvp(identifier: String, eventId: String, requestBody: SendRsvpRequest, queryParams: SendRsvpQueryParams, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/events/%s/send-rsvp", identifier, PathEncoder.encode(eventId))
+    val path = String.format("v3/grants/%s/events/%s/send-rsvp", PathEncoder.encode(identifier), PathEncoder.encode(eventId))
     val adapter = JsonHelper.moshi().adapter(SendRsvpRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
 

--- a/src/main/kotlin/com/nylas/resources/Events.kt
+++ b/src/main/kotlin/com/nylas/resources/Events.kt
@@ -24,7 +24,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @JvmOverloads
   fun list(identifier: String, queryParams: ListEventQueryParams, overrides: RequestOverrides? = null): ListResponse<Event> {
     val path = String.format("v3/grants/%s/events", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -41,7 +41,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @JvmOverloads
   fun listImportEvents(identifier: String, queryParams: ListImportEventQueryParams, overrides: RequestOverrides? = null): ListResponse<Event> {
     val path = String.format("v3/grants/%s/events/import", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -56,7 +56,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @JvmOverloads
   fun find(identifier: String, eventId: String, queryParams: FindEventQueryParams, overrides: RequestOverrides? = null): Response<Event> {
     val path = String.format("v3/grants/%s/events/%s", identifier, PathEncoder.encode(eventId))
-    return findResource(path, queryParams, overrides)
+    return findResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -73,7 +73,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
     val path = String.format("v3/grants/%s/events", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateEventRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, queryParams, overrides)
+    return createResourceEncoded(path, serializedRequestBody, queryParams, overrides)
   }
 
   /**
@@ -91,7 +91,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
     val path = String.format("v3/grants/%s/events/%s", identifier, PathEncoder.encode(eventId))
     val adapter = JsonHelper.moshi().adapter(UpdateEventRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, queryParams, overrides)
+    return updateResourceEncoded(path, serializedRequestBody, queryParams, overrides)
   }
 
   /**
@@ -106,7 +106,7 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
   @JvmOverloads
   fun destroy(identifier: String, eventId: String, queryParams: DestroyEventQueryParams, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/events/%s", identifier, PathEncoder.encode(eventId))
-    return destroyResource(path, queryParams, overrides)
+    return destroyResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -125,6 +125,6 @@ class Events(client: NylasClient) : Resource<Event>(client, Event::class.java) {
     val adapter = JsonHelper.moshi().adapter(SendRsvpRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
 
-    return client.executePost(path, DeleteResponse::class.java, serializedRequestBody, queryParams, overrides)
+    return client.executePostEncoded(path, DeleteResponse::class.java, serializedRequestBody, queryParams, overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Folders.kt
+++ b/src/main/kotlin/com/nylas/resources/Folders.kt
@@ -17,7 +17,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @JvmOverloads
   fun list(identifier: String, queryParams: ListFoldersQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Folder> {
     val path = String.format("v3/grants/%s/folders", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -31,7 +31,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @JvmOverloads
   fun find(identifier: String, folderId: String, overrides: RequestOverrides? = null): Response<Folder> {
     val path = String.format("v3/grants/%s/folders/%s", identifier, PathEncoder.encode(folderId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -47,7 +47,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
     val path = String.format("v3/grants/%s/folders", identifier)
     val adapter = JsonHelper.moshi().adapter(CreateFolderRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -64,7 +64,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
     val path = String.format("v3/grants/%s/folders/%s", identifier, PathEncoder.encode(folderId))
     val adapter = JsonHelper.moshi().adapter(UpdateFolderRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -78,6 +78,6 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @JvmOverloads
   fun destroy(identifier: String, folderId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/folders/%s", identifier, PathEncoder.encode(folderId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Folders.kt
+++ b/src/main/kotlin/com/nylas/resources/Folders.kt
@@ -16,7 +16,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListFoldersQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Folder> {
-    val path = String.format("v3/grants/%s/folders", identifier)
+    val path = String.format("v3/grants/%s/folders", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -30,7 +30,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, folderId: String, overrides: RequestOverrides? = null): Response<Folder> {
-    val path = String.format("v3/grants/%s/folders/%s", identifier, PathEncoder.encode(folderId))
+    val path = String.format("v3/grants/%s/folders/%s", PathEncoder.encode(identifier), PathEncoder.encode(folderId))
     return findResourceEncoded(path, overrides = overrides)
   }
 
@@ -44,7 +44,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun create(identifier: String, requestBody: CreateFolderRequest, overrides: RequestOverrides? = null): Response<Folder> {
-    val path = String.format("v3/grants/%s/folders", identifier)
+    val path = String.format("v3/grants/%s/folders", PathEncoder.encode(identifier))
     val adapter = JsonHelper.moshi().adapter(CreateFolderRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -61,7 +61,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, folderId: String, requestBody: UpdateFolderRequest, overrides: RequestOverrides? = null): Response<Folder> {
-    val path = String.format("v3/grants/%s/folders/%s", identifier, PathEncoder.encode(folderId))
+    val path = String.format("v3/grants/%s/folders/%s", PathEncoder.encode(identifier), PathEncoder.encode(folderId))
     val adapter = JsonHelper.moshi().adapter(UpdateFolderRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -77,7 +77,7 @@ class Folders(client: NylasClient) : Resource<Folder>(client, Folder::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun destroy(identifier: String, folderId: String, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/folders/%s", identifier, PathEncoder.encode(folderId))
+    val path = String.format("v3/grants/%s/folders/%s", PathEncoder.encode(identifier), PathEncoder.encode(folderId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Messages.kt
+++ b/src/main/kotlin/com/nylas/resources/Messages.kt
@@ -26,7 +26,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListMessagesQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Message> {
-    val path = String.format("v3/grants/%s/messages", identifier)
+    val path = String.format("v3/grants/%s/messages", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -41,7 +41,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, messageId: String, queryParams: FindMessageQueryParams? = null, overrides: RequestOverrides? = null): Response<Message> {
-    val path = String.format("v3/grants/%s/messages/%s", identifier, PathEncoder.encode(messageId))
+    val path = String.format("v3/grants/%s/messages/%s", PathEncoder.encode(identifier), PathEncoder.encode(messageId))
     return findResourceEncoded(path, queryParams, overrides = overrides)
   }
 
@@ -56,7 +56,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, messageId: String, requestBody: UpdateMessageRequest, overrides: RequestOverrides? = null): Response<Message> {
-    val path = String.format("v3/grants/%s/messages/%s", identifier, PathEncoder.encode(messageId))
+    val path = String.format("v3/grants/%s/messages/%s", PathEncoder.encode(identifier), PathEncoder.encode(messageId))
     val adapter = JsonHelper.moshi().adapter(UpdateMessageRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -72,7 +72,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun destroy(identifier: String, messageId: String, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/messages/%s", identifier, PathEncoder.encode(messageId))
+    val path = String.format("v3/grants/%s/messages/%s", PathEncoder.encode(identifier), PathEncoder.encode(messageId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 
@@ -86,7 +86,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun send(identifier: String, requestBody: SendMessageRequest, overrides: RequestOverrides? = null): Response<Message> {
-    val path = String.format("v3/grants/%s/messages/send", identifier)
+    val path = String.format("v3/grants/%s/messages/send", PathEncoder.encode(identifier))
     val responseType = Types.newParameterizedType(Response::class.java, Message::class.java)
     val adapter = JsonHelper.moshi().adapter(SendMessageRequest::class.java)
 
@@ -114,7 +114,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun listScheduledMessages(identifier: String, overrides: RequestOverrides? = null): ListResponse<ScheduledMessage> {
-    val path = String.format("v3/grants/%s/messages/schedules", identifier)
+    val path = String.format("v3/grants/%s/messages/schedules", PathEncoder.encode(identifier))
     val responseType = Types.newParameterizedType(ListResponse::class.java, ScheduledMessage::class.java)
     return client.executeGetEncoded(path, responseType, overrides = overrides)
   }
@@ -129,7 +129,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun findScheduledMessage(identifier: String, scheduleId: String, overrides: RequestOverrides? = null): Response<ScheduledMessage> {
-    val path = String.format("v3/grants/%s/messages/schedules/%s", identifier, PathEncoder.encode(scheduleId))
+    val path = String.format("v3/grants/%s/messages/schedules/%s", PathEncoder.encode(identifier), PathEncoder.encode(scheduleId))
     val responseType = Types.newParameterizedType(Response::class.java, ScheduledMessage::class.java)
     return client.executeGetEncoded(path, responseType, overrides = overrides)
   }
@@ -143,7 +143,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   fun stopScheduledMessage(identifier: String, scheduleId: String, overrides: RequestOverrides? = null): Response<StopScheduledMessageResponse> {
-    val path = String.format("v3/grants/%s/messages/schedules/%s", identifier, PathEncoder.encode(scheduleId))
+    val path = String.format("v3/grants/%s/messages/schedules/%s", PathEncoder.encode(identifier), PathEncoder.encode(scheduleId))
     val responseType = Types.newParameterizedType(Response::class.java, StopScheduledMessageResponse::class.java)
     return client.executeDeleteEncoded(path, responseType, overrides = overrides)
   }
@@ -156,7 +156,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
    */
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   fun cleanMessages(identifier: String, requestBody: CleanMessagesRequest): ListResponse<CleanMessagesResponse> {
-    val path = String.format("v3/grants/%s/messages/clean", identifier)
+    val path = String.format("v3/grants/%s/messages/clean", PathEncoder.encode(identifier))
     val adapter = JsonHelper.moshi().adapter(CleanMessagesRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     val responseType = Types.newParameterizedType(ListResponse::class.java, CleanMessagesResponse::class.java)

--- a/src/main/kotlin/com/nylas/resources/Messages.kt
+++ b/src/main/kotlin/com/nylas/resources/Messages.kt
@@ -27,7 +27,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @JvmOverloads
   fun list(identifier: String, queryParams: ListMessagesQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Message> {
     val path = String.format("v3/grants/%s/messages", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -42,7 +42,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @JvmOverloads
   fun find(identifier: String, messageId: String, queryParams: FindMessageQueryParams? = null, overrides: RequestOverrides? = null): Response<Message> {
     val path = String.format("v3/grants/%s/messages/%s", identifier, PathEncoder.encode(messageId))
-    return findResource(path, queryParams, overrides = overrides)
+    return findResourceEncoded(path, queryParams, overrides = overrides)
   }
 
   /**
@@ -59,7 +59,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
     val path = String.format("v3/grants/%s/messages/%s", identifier, PathEncoder.encode(messageId))
     val adapter = JsonHelper.moshi().adapter(UpdateMessageRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -73,7 +73,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   @JvmOverloads
   fun destroy(identifier: String, messageId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/messages/%s", identifier, PathEncoder.encode(messageId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -98,10 +98,10 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
       val serializedRequestBody = adapter.toJson(attachmentLessPayload)
       val multipart = FileUtils.buildFormRequest(requestBody, serializedRequestBody)
 
-      client.executeFormRequest(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
+      client.executeFormRequestEncoded(path, NylasClient.HttpMethod.POST, multipart, responseType, overrides = overrides)
     } else {
       val serializedRequestBody = adapter.toJson(requestBody)
-      createResource(path, serializedRequestBody, overrides = overrides)
+      createResourceEncoded(path, serializedRequestBody, overrides = overrides)
     }
   }
 
@@ -116,7 +116,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   fun listScheduledMessages(identifier: String, overrides: RequestOverrides? = null): ListResponse<ScheduledMessage> {
     val path = String.format("v3/grants/%s/messages/schedules", identifier)
     val responseType = Types.newParameterizedType(ListResponse::class.java, ScheduledMessage::class.java)
-    return client.executeGet(path, responseType, overrides = overrides)
+    return client.executeGetEncoded(path, responseType, overrides = overrides)
   }
 
   /**
@@ -131,7 +131,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   fun findScheduledMessage(identifier: String, scheduleId: String, overrides: RequestOverrides? = null): Response<ScheduledMessage> {
     val path = String.format("v3/grants/%s/messages/schedules/%s", identifier, PathEncoder.encode(scheduleId))
     val responseType = Types.newParameterizedType(Response::class.java, ScheduledMessage::class.java)
-    return client.executeGet(path, responseType, overrides = overrides)
+    return client.executeGetEncoded(path, responseType, overrides = overrides)
   }
 
   /**
@@ -145,7 +145,7 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
   fun stopScheduledMessage(identifier: String, scheduleId: String, overrides: RequestOverrides? = null): Response<StopScheduledMessageResponse> {
     val path = String.format("v3/grants/%s/messages/schedules/%s", identifier, PathEncoder.encode(scheduleId))
     val responseType = Types.newParameterizedType(Response::class.java, StopScheduledMessageResponse::class.java)
-    return client.executeDelete(path, responseType, overrides = overrides)
+    return client.executeDeleteEncoded(path, responseType, overrides = overrides)
   }
 
   /**
@@ -160,6 +160,6 @@ class Messages(client: NylasClient) : Resource<Message>(client, Message::class.j
     val adapter = JsonHelper.moshi().adapter(CleanMessagesRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     val responseType = Types.newParameterizedType(ListResponse::class.java, CleanMessagesResponse::class.java)
-    return client.executePut(path, responseType, serializedRequestBody)
+    return client.executePutEncoded(path, responseType, serializedRequestBody)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Notetakers.kt
+++ b/src/main/kotlin/com/nylas/resources/Notetakers.kt
@@ -22,7 +22,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     overrides: RequestOverrides? = null,
   ): ListResponse<Notetaker> {
     val path = identifier?.let { String.format("v3/grants/%s/notetakers", it) } ?: "v3/notetakers"
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -40,7 +40,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     overrides: RequestOverrides? = null,
   ): Response<Notetaker> {
     val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s", PathEncoder.encode(notetakerId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -60,7 +60,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     val path = identifier?.let { String.format("v3/grants/%s/notetakers", it) } ?: "v3/notetakers"
     val adapter = JsonHelper.moshi().adapter(CreateNotetakerRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -82,7 +82,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s", PathEncoder.encode(notetakerId))
     val adapter = JsonHelper.moshi().adapter(UpdateNotetakerRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -101,7 +101,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
   ): Response<LeaveNotetakerResponse> {
     val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/leave", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/leave", PathEncoder.encode(notetakerId))
     val responseType = Types.newParameterizedType(Response::class.java, LeaveNotetakerResponse::class.java)
-    return client.executePost(path, responseType, null, null, overrides)
+    return client.executePostEncoded(path, responseType, null, null, overrides)
   }
 
   /**
@@ -120,7 +120,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
   ): Response<NotetakerMediaResponse> {
     val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/media", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/media", PathEncoder.encode(notetakerId))
     val type = Types.newParameterizedType(Response::class.java, NotetakerMediaResponse::class.java)
-    return client.executeGet(path, type, null, overrides)
+    return client.executeGetEncoded(path, type, null, overrides)
   }
 
   /**
@@ -138,6 +138,6 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     overrides: RequestOverrides? = null,
   ): DeleteResponse {
     val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/cancel", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/cancel", PathEncoder.encode(notetakerId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Notetakers.kt
+++ b/src/main/kotlin/com/nylas/resources/Notetakers.kt
@@ -21,7 +21,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): ListResponse<Notetaker> {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers", it) } ?: "v3/notetakers"
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers", PathEncoder.encode(it)) } ?: "v3/notetakers"
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -39,7 +39,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): Response<Notetaker> {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s", PathEncoder.encode(notetakerId))
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s", PathEncoder.encode(it), PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s", PathEncoder.encode(notetakerId))
     return findResourceEncoded(path, overrides = overrides)
   }
 
@@ -57,7 +57,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): Response<Notetaker> {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers", it) } ?: "v3/notetakers"
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers", PathEncoder.encode(it)) } ?: "v3/notetakers"
     val adapter = JsonHelper.moshi().adapter(CreateNotetakerRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -79,7 +79,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): Response<Notetaker> {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s", PathEncoder.encode(notetakerId))
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s", PathEncoder.encode(it), PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s", PathEncoder.encode(notetakerId))
     val adapter = JsonHelper.moshi().adapter(UpdateNotetakerRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -99,7 +99,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): Response<LeaveNotetakerResponse> {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/leave", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/leave", PathEncoder.encode(notetakerId))
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/leave", PathEncoder.encode(it), PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/leave", PathEncoder.encode(notetakerId))
     val responseType = Types.newParameterizedType(Response::class.java, LeaveNotetakerResponse::class.java)
     return client.executePostEncoded(path, responseType, null, null, overrides)
   }
@@ -118,7 +118,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): Response<NotetakerMediaResponse> {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/media", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/media", PathEncoder.encode(notetakerId))
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/media", PathEncoder.encode(it), PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/media", PathEncoder.encode(notetakerId))
     val type = Types.newParameterizedType(Response::class.java, NotetakerMediaResponse::class.java)
     return client.executeGetEncoded(path, type, null, overrides)
   }
@@ -137,7 +137,7 @@ class Notetakers(client: NylasClient) : Resource<Notetaker>(client, Notetaker::c
     identifier: String? = null,
     overrides: RequestOverrides? = null,
   ): DeleteResponse {
-    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/cancel", it, PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/cancel", PathEncoder.encode(notetakerId))
+    val path = identifier?.let { String.format("v3/grants/%s/notetakers/%s/cancel", PathEncoder.encode(it), PathEncoder.encode(notetakerId)) } ?: String.format("v3/notetakers/%s/cancel", PathEncoder.encode(notetakerId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/NylasLists.kt
+++ b/src/main/kotlin/com/nylas/resources/NylasLists.kt
@@ -24,7 +24,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(queryParams: ListNylasListsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<NylasList> {
-    return listResource("v3/lists", queryParams, overrides)
+    return listResourceEncoded("v3/lists", queryParams, overrides)
   }
 
   /**
@@ -37,7 +37,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
   @JvmOverloads
   fun find(listId: String, overrides: RequestOverrides? = null): Response<NylasList> {
     val path = String.format("v3/lists/%s", PathEncoder.encode(listId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -50,7 +50,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
   @JvmOverloads
   fun create(requestBody: CreateNylasListRequest, overrides: RequestOverrides? = null): Response<NylasList> {
     val serializedRequestBody = JsonHelper.moshi().adapter(CreateNylasListRequest::class.java).toJson(requestBody)
-    return createResource("v3/lists", serializedRequestBody, overrides = overrides)
+    return createResourceEncoded("v3/lists", serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -66,7 +66,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
   fun update(listId: String, requestBody: UpdateNylasListRequest, overrides: RequestOverrides? = null): Response<NylasList> {
     val path = String.format("v3/lists/%s", PathEncoder.encode(listId))
     val serializedRequestBody = JsonHelper.moshi().adapter(UpdateNylasListRequest::class.java).toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -79,7 +79,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
   @JvmOverloads
   fun destroy(listId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/lists/%s", PathEncoder.encode(listId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -98,7 +98,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
   ): ListResponse<NylasListItem> {
     val path = String.format("v3/lists/%s/items", PathEncoder.encode(listId))
     val responseType = Types.newParameterizedType(ListResponse::class.java, NylasListItem::class.java)
-    return client.executeGet(path, responseType, queryParams, overrides)
+    return client.executeGetEncoded(path, responseType, queryParams, overrides)
   }
 
   /**
@@ -118,7 +118,7 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
     val path = String.format("v3/lists/%s/items", PathEncoder.encode(listId))
     val serializedRequestBody = JsonHelper.moshi().adapter(ListItemsRequest::class.java).toJson(requestBody)
     val responseType = Types.newParameterizedType(Response::class.java, NylasList::class.java)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -138,6 +138,6 @@ class NylasLists(client: NylasClient) : Resource<NylasList>(client, NylasList::c
     val path = String.format("v3/lists/%s/items", PathEncoder.encode(listId))
     val serializedRequestBody = JsonHelper.moshi().adapter(ListItemsRequest::class.java).toJson(requestBody)
     val responseType = Types.newParameterizedType(Response::class.java, NylasList::class.java)
-    return client.executeDelete(path, responseType, serializedRequestBody, overrides = overrides)
+    return client.executeDeleteEncoded(path, responseType, serializedRequestBody, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Policies.kt
+++ b/src/main/kotlin/com/nylas/resources/Policies.kt
@@ -23,7 +23,7 @@ class Policies(client: NylasClient) : Resource<Policy>(client, Policy::class.jav
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(queryParams: ListPoliciesQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Policy> {
-    return listResource("v3/policies", queryParams, overrides)
+    return listResourceEncoded("v3/policies", queryParams, overrides)
   }
 
   /**
@@ -36,7 +36,7 @@ class Policies(client: NylasClient) : Resource<Policy>(client, Policy::class.jav
   @JvmOverloads
   fun find(policyId: String, overrides: RequestOverrides? = null): Response<Policy> {
     val path = String.format("v3/policies/%s", PathEncoder.encode(policyId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -49,7 +49,7 @@ class Policies(client: NylasClient) : Resource<Policy>(client, Policy::class.jav
   @JvmOverloads
   fun create(requestBody: CreatePolicyRequest, overrides: RequestOverrides? = null): Response<Policy> {
     val serializedRequestBody = JsonHelper.moshi().adapter(CreatePolicyRequest::class.java).toJson(requestBody)
-    return createResource("v3/policies", serializedRequestBody, overrides = overrides)
+    return createResourceEncoded("v3/policies", serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -64,7 +64,7 @@ class Policies(client: NylasClient) : Resource<Policy>(client, Policy::class.jav
   fun update(policyId: String, requestBody: UpdatePolicyRequest, overrides: RequestOverrides? = null): Response<Policy> {
     val path = String.format("v3/policies/%s", PathEncoder.encode(policyId))
     val serializedRequestBody = JsonHelper.moshi().adapter(UpdatePolicyRequest::class.java).toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -77,6 +77,6 @@ class Policies(client: NylasClient) : Resource<Policy>(client, Policy::class.jav
   @JvmOverloads
   fun destroy(policyId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/policies/%s", PathEncoder.encode(policyId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/RedirectUris.kt
+++ b/src/main/kotlin/com/nylas/resources/RedirectUris.kt
@@ -22,7 +22,7 @@ class RedirectUris(client: NylasClient) : Resource<RedirectUri>(client, Redirect
   @JvmOverloads
   fun list(overrides: RequestOverrides? = null): ListResponse<RedirectUri> {
     val path = "v3/applications/redirect-uris"
-    return listResource(path, overrides = overrides)
+    return listResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -35,7 +35,7 @@ class RedirectUris(client: NylasClient) : Resource<RedirectUri>(client, Redirect
   @JvmOverloads
   fun find(redirectUriId: String, overrides: RequestOverrides? = null): Response<RedirectUri> {
     val path = String.format("v3/applications/redirect-uris/%s", PathEncoder.encode(redirectUriId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -52,7 +52,7 @@ class RedirectUris(client: NylasClient) : Resource<RedirectUri>(client, Redirect
       .adapter(CreateRedirectUriRequest::class.java)
       .toJson(requestBody)
 
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -70,7 +70,7 @@ class RedirectUris(client: NylasClient) : Resource<RedirectUri>(client, Redirect
       .adapter(UpdateRedirectUriRequest::class.java)
       .toJson(requestBody)
 
-    return patchResource(path, serializedRequestBody, overrides = overrides)
+    return patchResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -83,6 +83,6 @@ class RedirectUris(client: NylasClient) : Resource<RedirectUri>(client, Redirect
   @JvmOverloads
   fun destroy(redirectUriId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/applications/redirect-uris/%s", PathEncoder.encode(redirectUriId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Resource.kt
+++ b/src/main/kotlin/com/nylas/resources/Resource.kt
@@ -23,8 +23,18 @@ abstract class Resource<T> protected constructor(
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun listResourceEncoded(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<T> {
+    return client.executeGetEncoded(path, listResponseType, queryParams, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
   protected fun findResource(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
     return client.executeGet(path, responseType, queryParams, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun findResourceEncoded(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executeGetEncoded(path, responseType, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -33,8 +43,18 @@ abstract class Resource<T> protected constructor(
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun createResourceEncoded(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executePostEncoded(path, responseType, requestBody, queryParams, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
   protected fun updateResource(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
     return client.executePut(path, responseType, requestBody, queryParams, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun updateResourceEncoded(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executePutEncoded(path, responseType, requestBody, queryParams, overrides)
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
@@ -43,7 +63,17 @@ abstract class Resource<T> protected constructor(
   }
 
   @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun patchResourceEncoded(path: String, requestBody: String?, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): Response<T> {
+    return client.executePatchEncoded(path, responseType, requestBody, queryParams, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
   protected fun destroyResource(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): DeleteResponse {
     return client.executeDelete(path, DeleteResponse::class.java, queryParams, overrides)
+  }
+
+  @Throws(AbstractNylasApiError::class, NylasSdkTimeoutError::class)
+  protected fun destroyResourceEncoded(path: String, queryParams: IQueryParams? = null, overrides: RequestOverrides? = null): DeleteResponse {
+    return client.executeDeleteEncoded(path, DeleteResponse::class.java, queryParams, overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Rules.kt
+++ b/src/main/kotlin/com/nylas/resources/Rules.kt
@@ -39,7 +39,7 @@ class Rules(client: NylasClient) : Resource<Rule>(client, Rule::class.java) {
   @JvmOverloads
   fun find(ruleId: String, overrides: RequestOverrides? = null): Response<Rule> {
     val path = String.format("v3/rules/%s", PathEncoder.encode(ruleId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -52,7 +52,7 @@ class Rules(client: NylasClient) : Resource<Rule>(client, Rule::class.java) {
   @JvmOverloads
   fun create(requestBody: CreateRuleRequest, overrides: RequestOverrides? = null): Response<Rule> {
     val serializedRequestBody = JsonHelper.moshi().adapter(CreateRuleRequest::class.java).toJson(requestBody)
-    return createResource("v3/rules", serializedRequestBody, overrides = overrides)
+    return createResourceEncoded("v3/rules", serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -67,7 +67,7 @@ class Rules(client: NylasClient) : Resource<Rule>(client, Rule::class.java) {
   fun update(ruleId: String, requestBody: UpdateRuleRequest, overrides: RequestOverrides? = null): Response<Rule> {
     val path = String.format("v3/rules/%s", PathEncoder.encode(ruleId))
     val serializedRequestBody = JsonHelper.moshi().adapter(UpdateRuleRequest::class.java).toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -80,7 +80,7 @@ class Rules(client: NylasClient) : Resource<Rule>(client, Rule::class.java) {
   @JvmOverloads
   fun destroy(ruleId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/rules/%s", PathEncoder.encode(ruleId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -99,7 +99,7 @@ class Rules(client: NylasClient) : Resource<Rule>(client, Rule::class.java) {
   ): ListResponse<RuleEvaluation> {
     val path = String.format("v3/grants/%s/rule-evaluations", PathEncoder.encode(grantId))
     val responseType = Types.newParameterizedType(ListResponse::class.java, RuleEvaluation::class.java)
-    return client.executeGet(path, responseType, queryParams, overrides)
+    return client.executeGetEncoded(path, responseType, queryParams, overrides)
   }
 }
 

--- a/src/main/kotlin/com/nylas/resources/Sessions.kt
+++ b/src/main/kotlin/com/nylas/resources/Sessions.kt
@@ -24,7 +24,7 @@ class Sessions(client: NylasClient) : Resource<Session>(client, Session::class.j
     val path = "v3/scheduling/sessions"
     val adapter = JsonHelper.moshi().adapter(CreateSessionRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return createResource(path, serializedRequestBody, overrides = overrides)
+    return createResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -37,6 +37,6 @@ class Sessions(client: NylasClient) : Resource<Session>(client, Session::class.j
   @JvmOverloads
   fun destroy(sessionId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/scheduling/sessions/%s", PathEncoder.encode(sessionId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Threads.kt
+++ b/src/main/kotlin/com/nylas/resources/Threads.kt
@@ -17,7 +17,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @JvmOverloads
   fun list(identifier: String, queryParams: ListThreadsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Thread> {
     val path = String.format("v3/grants/%s/threads", identifier)
-    return listResource(path, queryParams, overrides)
+    return listResourceEncoded(path, queryParams, overrides)
   }
 
   /**
@@ -31,7 +31,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @JvmOverloads
   fun find(identifier: String, threadId: String, overrides: RequestOverrides? = null): Response<Thread> {
     val path = String.format("v3/grants/%s/threads/%s", identifier, PathEncoder.encode(threadId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -48,7 +48,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
     val path = String.format("v3/grants/%s/threads/%s", identifier, PathEncoder.encode(threadId))
     val adapter = JsonHelper.moshi().adapter(UpdateThreadRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -62,6 +62,6 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @JvmOverloads
   fun destroy(identifier: String, threadId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/grants/%s/threads/%s", identifier, PathEncoder.encode(threadId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Threads.kt
+++ b/src/main/kotlin/com/nylas/resources/Threads.kt
@@ -16,7 +16,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(identifier: String, queryParams: ListThreadsQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Thread> {
-    val path = String.format("v3/grants/%s/threads", identifier)
+    val path = String.format("v3/grants/%s/threads", PathEncoder.encode(identifier))
     return listResourceEncoded(path, queryParams, overrides)
   }
 
@@ -30,7 +30,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun find(identifier: String, threadId: String, overrides: RequestOverrides? = null): Response<Thread> {
-    val path = String.format("v3/grants/%s/threads/%s", identifier, PathEncoder.encode(threadId))
+    val path = String.format("v3/grants/%s/threads/%s", PathEncoder.encode(identifier), PathEncoder.encode(threadId))
     return findResourceEncoded(path, overrides = overrides)
   }
 
@@ -45,7 +45,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun update(identifier: String, threadId: String, requestBody: UpdateThreadRequest, overrides: RequestOverrides? = null): Response<Thread> {
-    val path = String.format("v3/grants/%s/threads/%s", identifier, PathEncoder.encode(threadId))
+    val path = String.format("v3/grants/%s/threads/%s", PathEncoder.encode(identifier), PathEncoder.encode(threadId))
     val adapter = JsonHelper.moshi().adapter(UpdateThreadRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
     return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
@@ -61,7 +61,7 @@ class Threads(client: NylasClient) : Resource<Thread>(client, Thread::class.java
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun destroy(identifier: String, threadId: String, overrides: RequestOverrides? = null): DeleteResponse {
-    val path = String.format("v3/grants/%s/threads/%s", identifier, PathEncoder.encode(threadId))
+    val path = String.format("v3/grants/%s/threads/%s", PathEncoder.encode(identifier), PathEncoder.encode(threadId))
     return destroyResourceEncoded(path, overrides = overrides)
   }
 }

--- a/src/main/kotlin/com/nylas/resources/Webhooks.kt
+++ b/src/main/kotlin/com/nylas/resources/Webhooks.kt
@@ -23,7 +23,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
   @JvmOverloads
   fun list(overrides: RequestOverrides? = null): ListResponse<Webhook> {
     val path = "v3/webhooks"
-    return listResource(path, overrides = overrides)
+    return listResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -36,7 +36,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
   @JvmOverloads
   fun find(webhookId: String, overrides: RequestOverrides? = null): Response<Webhook> {
     val path = String.format("v3/webhooks/%s", PathEncoder.encode(webhookId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -52,7 +52,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
     val adapter = JsonHelper.moshi().adapter(CreateWebhookRequest::class.java)
     val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -68,7 +68,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
     val path = String.format("v3/webhooks/%s", PathEncoder.encode(webhookId))
     val adapter = JsonHelper.moshi().adapter(UpdateWebhookRequest::class.java)
     val serializedRequestBody = adapter.toJson(requestBody)
-    return updateResource(path, serializedRequestBody, overrides = overrides)
+    return updateResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -81,7 +81,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
   @JvmOverloads
   fun destroy(webhookId: String, overrides: RequestOverrides? = null): WebhookDeleteResponse {
     val path = String.format("v3/webhooks/%s", PathEncoder.encode(webhookId))
-    return client.executeDelete(path, WebhookDeleteResponse::class.java, overrides = overrides)
+    return client.executeDeleteEncoded(path, WebhookDeleteResponse::class.java, overrides = overrides)
   }
 
   /**
@@ -95,7 +95,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
   fun rotateSecret(webhookId: String, overrides: RequestOverrides? = null): Response<WebhookWithSecret> {
     val path = String.format("v3/webhooks/rotate-secret/%s", PathEncoder.encode(webhookId))
     val responseType = Types.newParameterizedType(Response::class.java, WebhookWithSecret::class.java)
-    return client.executePost(path, responseType, overrides = overrides)
+    return client.executePostEncoded(path, responseType, overrides = overrides)
   }
 
   /**
@@ -108,7 +108,7 @@ class Webhooks(client: NylasClient) : Resource<Webhook>(client, Webhook::class.j
   fun ipAddresses(overrides: RequestOverrides? = null): Response<WebhookIpAddressesResponse> {
     val path = "v3/webhooks/ip-addresses"
     val responseType = Types.newParameterizedType(Response::class.java, WebhookIpAddressesResponse::class.java)
-    return client.executeGet(path, responseType, overrides = overrides)
+    return client.executeGetEncoded(path, responseType, overrides = overrides)
   }
 
   /**

--- a/src/main/kotlin/com/nylas/resources/Workspaces.kt
+++ b/src/main/kotlin/com/nylas/resources/Workspaces.kt
@@ -24,7 +24,7 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
   @Throws(NylasApiError::class, NylasSdkTimeoutError::class)
   @JvmOverloads
   fun list(queryParams: ListWorkspacesQueryParams? = null, overrides: RequestOverrides? = null): ListResponse<Workspace> {
-    return listResource("v3/workspaces", queryParams, overrides)
+    return listResourceEncoded("v3/workspaces", queryParams, overrides)
   }
 
   /**
@@ -37,7 +37,7 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
   @JvmOverloads
   fun find(workspaceId: String, overrides: RequestOverrides? = null): Response<Workspace> {
     val path = String.format("v3/workspaces/%s", PathEncoder.encode(workspaceId))
-    return findResource(path, overrides = overrides)
+    return findResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -50,7 +50,7 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
   @JvmOverloads
   fun create(requestBody: CreateWorkspaceRequest, overrides: RequestOverrides? = null): Response<Workspace> {
     val serializedRequestBody = JsonHelper.moshi().adapter(CreateWorkspaceRequest::class.java).toJson(requestBody)
-    return createResource("v3/workspaces", serializedRequestBody, overrides = overrides)
+    return createResourceEncoded("v3/workspaces", serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -65,7 +65,7 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
   fun update(workspaceId: String, requestBody: UpdateWorkspaceRequest, overrides: RequestOverrides? = null): Response<Workspace> {
     val path = String.format("v3/workspaces/%s", PathEncoder.encode(workspaceId))
     val serializedRequestBody = JsonHelper.moshi().adapter(UpdateWorkspaceRequest::class.java).toJson(requestBody)
-    return patchResource(path, serializedRequestBody, overrides = overrides)
+    return patchResourceEncoded(path, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -78,7 +78,7 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
   @JvmOverloads
   fun destroy(workspaceId: String, overrides: RequestOverrides? = null): DeleteResponse {
     val path = String.format("v3/workspaces/%s", PathEncoder.encode(workspaceId))
-    return destroyResource(path, overrides = overrides)
+    return destroyResourceEncoded(path, overrides = overrides)
   }
 
   /**
@@ -97,7 +97,7 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
     val serializedRequestBody = requestBody?.let {
       JsonHelper.moshi().adapter(WorkspaceAutoGroupRequest::class.java).toJson(it)
     }
-    return client.executePost("v3/workspaces/auto-group", responseType, serializedRequestBody, overrides = overrides)
+    return client.executePostEncoded("v3/workspaces/auto-group", responseType, serializedRequestBody, overrides = overrides)
   }
 
   /**
@@ -117,6 +117,6 @@ class Workspaces(client: NylasClient) : Resource<Workspace>(client, Workspace::c
     val path = String.format("v3/workspaces/%s/manual-assign", PathEncoder.encode(workspaceId))
     val responseType = Types.newParameterizedType(Response::class.java, WorkspaceManualAssignResponse::class.java)
     val serializedRequestBody = JsonHelper.moshi().adapter(WorkspaceManualAssignRequest::class.java).toJson(requestBody)
-    return client.executePost(path, responseType, serializedRequestBody, overrides = overrides)
+    return client.executePostEncoded(path, responseType, serializedRequestBody, overrides = overrides)
   }
 }

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -2,6 +2,7 @@ package com.nylas
 
 import com.nylas.models.*
 import com.nylas.util.JsonHelper
+import com.nylas.util.PathEncoder
 import okhttp3.*
 import okhttp3.Response
 import okio.Buffer
@@ -390,6 +391,26 @@ class NylasClientTest {
       assertEquals(mockResponseBody, result)
       assertEquals(capturedRequest.url.toString(), "https://api.us.nylas.com/test/path")
       assertEquals(capturedRequest.method, "GET")
+    }
+    @Test
+    fun `pre-encoded path segments are not double-encoded`() {
+      // Simulates the path a resource builds for a Gmail attachment id ("v0:<...>:<...>:<size>")
+      // after the resource layer percent-encodes it with PathEncoder.
+      val attachmentId = "v0:UHJvZ3JhbW1l:YXBwbGljYXRpb24=:15204"
+      val path = "v3/grants/abc-123-grant-id/attachments/${PathEncoder.encode(attachmentId)}/download"
+
+      nylasClient.downloadResponse(path)
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+
+      // The ':' and '=' are encoded exactly once ('%3A', '%3D'); they must NOT become '%253A'/'%253D'.
+      assertEquals(
+        "https://api.us.nylas.com/v3/grants/abc-123-grant-id/attachments/v0%3AUHJvZ3JhbW1l%3AYXBwbGljYXRpb24%3D%3A15204/download",
+        capturedRequest.url.toString(),
+      )
+      assertEquals(attachmentId, capturedRequest.url.pathSegments[4])
     }
 
     @Test

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -400,7 +400,7 @@ class NylasClientTest {
       val attachmentId = "v0:UHJvZ3JhbW1l:YXBwbGljYXRpb24=:15204"
       val path = "v3/grants/abc-123-grant-id/attachments/${PathEncoder.encode(attachmentId)}/download"
 
-      nylasClient.downloadResponse(path)
+      nylasClient.downloadResponseEncoded(path)
 
       val requestCaptor = argumentCaptor<Request>()
       verify(mockHttpClient).newCall(requestCaptor.capture())

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -204,6 +204,24 @@ class NylasClientTest {
       val result = nylasClient.domains()
       assertNotNull(result)
     }
+
+    @Test
+    fun `policies returns a valid Policies instance`() {
+      val result = nylasClient.policies()
+      assertNotNull(result)
+    }
+
+    @Test
+    fun `workspaces returns a valid Workspaces instance`() {
+      val result = nylasClient.workspaces()
+      assertNotNull(result)
+    }
+
+    @Test
+    fun `lists returns a valid NylasLists instance`() {
+      val result = nylasClient.lists()
+      assertNotNull(result)
+    }
   }
 
   @Nested
@@ -502,6 +520,22 @@ class NylasClientTest {
     }
 
     @Test
+    fun `executePutEncoded should preserve encoded path segments`() {
+      val putBody = "{ \"test\": \"updated\" }"
+      val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
+      whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
+      nylasClient.executePutEncoded<Map<String, String>>("test/path%2Fsegment", type, putBody)
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+
+      assertEquals("https://api.us.nylas.com/test/path%2Fsegment", capturedRequest.url.toString())
+      assertEquals("PUT", capturedRequest.method)
+      assertEquals(putBody, capturedRequest.body.asString())
+    }
+
+    @Test
     fun `executePatch should set up the request with the correct params`() {
       val patchBody = "{ \"test\": \"updated\" }"
       val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
@@ -516,6 +550,22 @@ class NylasClientTest {
       assertEquals(capturedRequest.url.toString(), "https://api.us.nylas.com/test/path")
       assertEquals(capturedRequest.method, "PATCH")
       assertEquals(requestBodyBuffer, patchBody)
+    }
+
+    @Test
+    fun `executePatchEncoded should preserve encoded path segments`() {
+      val patchBody = "{ \"test\": \"updated\" }"
+      val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
+      whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
+      nylasClient.executePatchEncoded<Map<String, String>>("test/path%2Fsegment", type, patchBody)
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+
+      assertEquals("https://api.us.nylas.com/test/path%2Fsegment", capturedRequest.url.toString())
+      assertEquals("PATCH", capturedRequest.method)
+      assertEquals(patchBody, capturedRequest.body.asString())
     }
 
     @Test
@@ -536,6 +586,22 @@ class NylasClientTest {
     }
 
     @Test
+    fun `executePostEncoded should preserve encoded path segments`() {
+      val postBody = "{ \"test\": \"updated\" }"
+      val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
+      whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
+      nylasClient.executePostEncoded<Map<String, String>>("test/path%2Fsegment", type, postBody)
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+
+      assertEquals("https://api.us.nylas.com/test/path%2Fsegment", capturedRequest.url.toString())
+      assertEquals("POST", capturedRequest.method)
+      assertEquals(postBody, capturedRequest.body.asString())
+    }
+
+    @Test
     fun `executeDelete should set up the request with the correct params`() {
       val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
       whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
@@ -547,6 +613,20 @@ class NylasClientTest {
 
       assertEquals(capturedRequest.url.toString(), "https://api.us.nylas.com/test/path")
       assertEquals(capturedRequest.method, "DELETE")
+    }
+
+    @Test
+    fun `executeDeleteEncoded should preserve encoded path segments`() {
+      val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
+      whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
+      nylasClient.executeDeleteEncoded<Map<String, String>>("test/path%2Fsegment", type)
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+
+      assertEquals("https://api.us.nylas.com/test/path%2Fsegment", capturedRequest.url.toString())
+      assertEquals("DELETE", capturedRequest.method)
     }
 
     @Test
@@ -564,6 +644,42 @@ class NylasClientTest {
       assertEquals(capturedRequest.url.toString(), "https://api.us.nylas.com/test/path")
       assertEquals(capturedRequest.method, "DELETE")
       assertEquals(requestBodyBuffer, deleteBody)
+    }
+
+    @Test
+    fun `executeDeleteEncoded with a request body should preserve encoded path segments`() {
+      val deleteBody = "{ \"cancellation_reason\": \"No longer available\" }"
+      val type = JsonHelper.mapTypeOf(String::class.java, String::class.java)
+      whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
+      nylasClient.executeDeleteEncoded<Map<String, String>>("test/path%2Fsegment", type, deleteBody)
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+
+      assertEquals("https://api.us.nylas.com/test/path%2Fsegment", capturedRequest.url.toString())
+      assertEquals("DELETE", capturedRequest.method)
+      assertEquals(deleteBody, capturedRequest.body.asString())
+    }
+
+    @Test
+    fun `executeFormRequestEncoded should preserve encoded path segments`() {
+      whenever(mockResponseBody.source()).thenReturn(Buffer().writeUtf8("{ \"foo\": \"bar\" }"))
+      val multipartBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
+      multipartBuilder.addFormDataPart("message", "abc123")
+
+      nylasClient.executeFormRequestEncoded<Map<String, String>>(
+        "test/path%2Fsegment",
+        NylasClient.HttpMethod.POST,
+        multipartBuilder.build(),
+        JsonHelper.mapTypeOf(String::class.java, String::class.java),
+      )
+
+      val requestCaptor = argumentCaptor<Request>()
+      verify(mockHttpClient).newCall(requestCaptor.capture())
+      val capturedRequest = requestCaptor.firstValue
+      assertEquals("https://api.us.nylas.com/test/path%2Fsegment", capturedRequest.url.toString())
+      assertEquals("POST", capturedRequest.method)
     }
 
     /**

--- a/src/test/kotlin/com/nylas/NylasClientTest.kt
+++ b/src/test/kotlin/com/nylas/NylasClientTest.kt
@@ -392,6 +392,7 @@ class NylasClientTest {
       assertEquals(capturedRequest.url.toString(), "https://api.us.nylas.com/test/path")
       assertEquals(capturedRequest.method, "GET")
     }
+
     @Test
     fun `pre-encoded path segments are not double-encoded`() {
       // Simulates the path a resource builds for a Gmail attachment id ("v0:<...>:<...>:<size>")

--- a/src/test/kotlin/com/nylas/resources/AttachmentsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/AttachmentsTests.kt
@@ -93,7 +93,7 @@ class AttachmentsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindAttachmentQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Attachment>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Attachment>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -111,7 +111,7 @@ class AttachmentsTests {
       val pathCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).downloadResponse(
+      verify(mockNylasClient).downloadResponseEncoded(
         pathCaptor.capture(),
         queryParamCaptor.capture(),
         overrideParamCaptor.capture(),
@@ -124,14 +124,14 @@ class AttachmentsTests {
     fun `downloadBytes makes a GET request to the correct path`() {
       val byteArray = byteArrayOf(0b00000100, 0b00000010, 0b00000011)
       whenever(mockResponseBody.bytes()).thenReturn(byteArray)
-      whenever(mockNylasClient.downloadResponse(any(), any(), overrides = eq(null))).thenReturn(mockResponseBody)
+      whenever(mockNylasClient.downloadResponseEncoded(any(), any(), overrides = eq(null))).thenReturn(mockResponseBody)
 
       val bytes = attachments.downloadBytes(grantId, attachmentId, queryParams)
 
       val pathCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).downloadResponse(
+      verify(mockNylasClient).downloadResponseEncoded(
         pathCaptor.capture(),
         queryParamCaptor.capture(),
         overrideParamCaptor.capture(),
@@ -152,7 +152,7 @@ class AttachmentsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Attachment>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Attachment>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/AttachmentsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/AttachmentsTests.kt
@@ -3,6 +3,7 @@ package com.nylas.resources
 import com.nylas.NylasClient
 import com.nylas.models.*
 import com.nylas.util.JsonHelper
+import com.nylas.util.PathEncoder
 import com.squareup.moshi.Types
 import okhttp3.Call
 import okhttp3.Interceptor
@@ -160,6 +161,27 @@ class AttachmentsTests {
       )
 
       assertEquals("v3/grants/$grantId/attachments/INBOX%2Fattach-123", pathCaptor.firstValue)
+    }
+
+    @Test
+    fun `download URL-encodes a grant identifier containing reserved characters`() {
+      val reservedGrantId = "grant/user@example.com"
+
+      attachments.download(reservedGrantId, attachmentId, queryParams)
+
+      val pathCaptor = argumentCaptor<String>()
+      val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).downloadResponseEncoded(
+        pathCaptor.capture(),
+        queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals(
+        "v3/grants/${PathEncoder.encode(reservedGrantId)}/attachments/$attachmentId/download",
+        pathCaptor.firstValue,
+      )
     }
   }
 }

--- a/src/test/kotlin/com/nylas/resources/BookingsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/BookingsTest.kt
@@ -104,7 +104,7 @@ class BookingsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<CreateBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Booking>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executePostEncoded<Booking>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
 
       assertEquals("v3/scheduling/bookings", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Booking::class.java), typeCaptor.firstValue)
@@ -120,7 +120,7 @@ class BookingsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Booking>(pathCaptor.capture(), typeCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executeGetEncoded<Booking>(pathCaptor.capture(), typeCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
 
       assertEquals("v3/scheduling/bookings/$bookingId", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Booking::class.java), typeCaptor.firstValue)
@@ -141,7 +141,7 @@ class BookingsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<RescheduleBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePatch<Booking>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executePatchEncoded<Booking>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
 
       assertEquals("v3/scheduling/bookings/$bookingId", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Booking::class.java), typeCaptor.firstValue)
@@ -164,7 +164,7 @@ class BookingsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ConfirmBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Booking>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executePutEncoded<Booking>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
 
       assertEquals("v3/scheduling/bookings/$bookingId", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Booking::class.java), typeCaptor.firstValue)
@@ -180,7 +180,7 @@ class BookingsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<DestroyBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(pathCaptor.capture(), typeCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(pathCaptor.capture(), typeCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
 
       assertEquals("v3/scheduling/bookings/$bookingId", pathCaptor.firstValue)
       assertEquals(DeleteResponse::class.java, typeCaptor.firstValue)
@@ -202,7 +202,7 @@ class BookingsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<DestroyBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -226,7 +226,7 @@ class BookingsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindBookingQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Booking>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Booking>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/CalendarsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/CalendarsTest.kt
@@ -551,7 +551,7 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Calendar>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -576,7 +576,7 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Calendar>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -596,7 +596,7 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Calendar>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -640,7 +640,7 @@ class CalendarsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Calendar>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -688,7 +688,7 @@ class CalendarsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Calendar>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -710,7 +710,7 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Calendar>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -731,7 +731,7 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Calendar>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -751,7 +751,7 @@ class CalendarsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Calendar>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -823,7 +823,7 @@ class CalendarsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Calendar>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -859,7 +859,7 @@ class CalendarsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Calendar>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -902,7 +902,7 @@ class CalendarsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Calendar>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -931,7 +931,7 @@ class CalendarsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Calendar>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Calendar>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/ConfigurationsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/ConfigurationsTest.kt
@@ -301,7 +301,7 @@ class ConfigurationsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Configuration>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -349,7 +349,7 @@ class ConfigurationsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Configuration>>(
+      verify(mockNylasClient).executePostEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -398,7 +398,7 @@ class ConfigurationsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Configuration>>(
+      verify(mockNylasClient).executePostEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -424,7 +424,7 @@ class ConfigurationsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Configuration>>(
+      verify(mockNylasClient).executePutEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -451,7 +451,7 @@ class ConfigurationsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Configuration>>(
+      verify(mockNylasClient).executePutEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -472,7 +472,7 @@ class ConfigurationsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Configuration>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -490,7 +490,7 @@ class ConfigurationsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -559,7 +559,7 @@ class ConfigurationsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Configuration>>(
+      verify(mockNylasClient).executePostEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -649,7 +649,7 @@ class ConfigurationsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListConfigurationsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Configuration>>(
+      verify(mockNylasClient).executePostEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -680,7 +680,7 @@ class ConfigurationsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Configuration>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Configuration>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/ContactsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/ContactsTests.kt
@@ -205,7 +205,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Contact>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -225,7 +225,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Contact>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -250,7 +250,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindContactQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Contact>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -272,7 +272,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindContactQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Contact>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -346,7 +346,7 @@ class ContactsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Contact>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -422,7 +422,7 @@ class ContactsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Contact>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -444,7 +444,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Contact>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -482,7 +482,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactGroupsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<ContactGroup>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<ContactGroup>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -504,7 +504,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListContactGroupsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<ContactGroup>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<ContactGroup>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -526,7 +526,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Contact>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -546,7 +546,7 @@ class ContactsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Contact>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Contact>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/CredentialsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/CredentialsTests.kt
@@ -235,7 +235,7 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Credential>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -255,7 +255,7 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Credential>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -277,7 +277,7 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Credential>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -307,7 +307,7 @@ class CredentialsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Credential>>(
+      verify(mockNylasClient).executePostEncoded<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -338,7 +338,7 @@ class CredentialsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Credential>>(
+      verify(mockNylasClient).executePostEncoded<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -371,7 +371,7 @@ class CredentialsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePatch<Response<Credential>>(
+      verify(mockNylasClient).executePatchEncoded<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -393,7 +393,7 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -423,7 +423,7 @@ class CredentialsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePatch<Response<Credential>>(
+      verify(mockNylasClient).executePatchEncoded<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -453,7 +453,7 @@ class CredentialsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Credential>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Credential>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/DomainsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DomainsTests.kt
@@ -242,7 +242,7 @@ class DomainsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Message>>(
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -267,7 +267,7 @@ class DomainsTests {
       domains.sendTransactionalEmail(domainName, request, overrides)
 
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Message>>(
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
         any(),
         any(),
         any(),
@@ -307,7 +307,7 @@ class DomainsTests {
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeFormRequest<Response<Message>>(
+      verify(mockNylasClient).executeFormRequestEncoded<Response<Message>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -353,7 +353,7 @@ class DomainsTests {
       domains.sendTransactionalEmail(domainName, request, overrides)
 
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeFormRequest<Response<Message>>(
+      verify(mockNylasClient).executeFormRequestEncoded<Response<Message>>(
         any(),
         any(),
         any(),
@@ -374,7 +374,7 @@ class DomainsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Domain>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Domain>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -497,7 +497,7 @@ class DomainsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Domain>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Domain>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -520,7 +520,7 @@ class DomainsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Domain>>(
+      verify(mockNylasClient).executePostEncoded<Response<Domain>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -545,7 +545,7 @@ class DomainsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Domain>>(
+      verify(mockNylasClient).executePutEncoded<Response<Domain>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -568,7 +568,7 @@ class DomainsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -591,7 +591,7 @@ class DomainsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<DomainVerificationResult>>(
+      verify(mockNylasClient).executePostEncoded<Response<DomainVerificationResult>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -616,7 +616,7 @@ class DomainsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<DomainVerificationResult>>(
+      verify(mockNylasClient).executePostEncoded<Response<DomainVerificationResult>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/DomainsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DomainsTests.kt
@@ -4,6 +4,7 @@ import com.nylas.NylasClient
 import com.nylas.models.*
 import com.nylas.models.Response
 import com.nylas.util.JsonHelper
+import com.nylas.util.PathEncoder
 import com.squareup.moshi.Types
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
@@ -275,6 +276,35 @@ class DomainsTests {
         overrideParamCaptor.capture(),
       )
       assertEquals("override-key", overrideParamCaptor.firstValue.apiKey)
+    }
+
+    @Test
+    fun `sending a transactional email URL-encodes a domain containing reserved characters`() {
+      val reservedDomainName = "mail/acme.example"
+      val request = SendTransactionalEmailRequest.Builder(
+        to = listOf(EmailName(email = "jane.doe@example.com", name = "Jane Doe")),
+        from = EmailName(email = "support@acme.com", name = "ACME Support"),
+      ).build()
+
+      domains.sendTransactionalEmail(reservedDomainName, request)
+
+      val pathCaptor = argumentCaptor<String>()
+      val typeCaptor = argumentCaptor<Type>()
+      val requestBodyCaptor = argumentCaptor<String>()
+      val queryParamCaptor = argumentCaptor<IQueryParams>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
+        pathCaptor.capture(),
+        typeCaptor.capture(),
+        requestBodyCaptor.capture(),
+        queryParamCaptor.capture(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals(
+        "v3/domains/${PathEncoder.encode(reservedDomainName)}/messages/send",
+        pathCaptor.firstValue,
+      )
     }
 
     @Test

--- a/src/test/kotlin/com/nylas/resources/DomainsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DomainsTests.kt
@@ -510,6 +510,28 @@ class DomainsTests {
     }
 
     @Test
+    fun `listing managed domains with signer calls requests with merged signer headers`() {
+      val signer = ServiceAccountSigner(testKeyPair().private, "service-account-key-id")
+      val queryParams = ListDomainsQueryParams(limit = 2)
+
+      domains.list(queryParams, signer, RequestOverrides(headers = mapOf("X-Custom" to "keep")))
+
+      val pathCaptor = argumentCaptor<String>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Domain>>(
+        pathCaptor.capture(),
+        any(),
+        eq(queryParams),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals("v3/admin/domains", pathCaptor.firstValue)
+      assertEquals("keep", overrideParamCaptor.firstValue.headers?.get("X-Custom"))
+      assertEquals("service-account-key-id", overrideParamCaptor.firstValue.headers?.get("X-Nylas-Kid"))
+      assertTrue(overrideParamCaptor.firstValue.omitAuthorization)
+    }
+
+    @Test
     fun `creating a managed domain calls requests with the correct params`() {
       val requestBody = CreateDomainRequest(name = "Acme", domainAddress = "mail.acme.com")
       val overrides = serviceAccountOverrides()
@@ -532,6 +554,27 @@ class DomainsTests {
       assertEquals(Types.newParameterizedType(Response::class.java, Domain::class.java), typeCaptor.firstValue)
       assertEquals("""{"domain_address":"mail.acme.com","name":"Acme"}""", requestBodyCaptor.firstValue)
       assertServiceAccountOverrides(overrides, overrideParamCaptor.firstValue)
+    }
+
+    @Test
+    fun `finding a managed domain with signer calls requests with merged signer headers`() {
+      val signer = ServiceAccountSigner(testKeyPair().private, "service-account-key-id")
+
+      domains.find("domain/with/slash", signer, RequestOverrides(headers = mapOf("X-Custom" to "keep")))
+
+      val pathCaptor = argumentCaptor<String>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executeGetEncoded<Response<Domain>>(
+        pathCaptor.capture(),
+        any(),
+        anyOrNull(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals("v3/admin/domains/domain%2Fwith%2Fslash", pathCaptor.firstValue)
+      assertEquals("keep", overrideParamCaptor.firstValue.headers?.get("X-Custom"))
+      assertEquals("service-account-key-id", overrideParamCaptor.firstValue.headers?.get("X-Nylas-Kid"))
+      assertTrue(overrideParamCaptor.firstValue.omitAuthorization)
     }
 
     @Test
@@ -560,6 +603,31 @@ class DomainsTests {
     }
 
     @Test
+    fun `updating a managed domain with signer calls requests with canonical body and signer headers`() {
+      val signer = ServiceAccountSigner(testKeyPair().private, "service-account-key-id")
+      val requestBody = UpdateDomainRequest(name = "Renamed")
+
+      domains.update("dom-123", requestBody, signer, RequestOverrides(headers = mapOf("X-Custom" to "keep")))
+
+      val pathCaptor = argumentCaptor<String>()
+      val requestBodyCaptor = argumentCaptor<String>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executePutEncoded<Response<Domain>>(
+        pathCaptor.capture(),
+        any(),
+        requestBodyCaptor.capture(),
+        anyOrNull(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals("v3/admin/domains/dom-123", pathCaptor.firstValue)
+      assertEquals("""{"name":"Renamed"}""", requestBodyCaptor.firstValue)
+      assertEquals("keep", overrideParamCaptor.firstValue.headers?.get("X-Custom"))
+      assertEquals("service-account-key-id", overrideParamCaptor.firstValue.headers?.get("X-Nylas-Kid"))
+      assertTrue(overrideParamCaptor.firstValue.omitAuthorization)
+    }
+
+    @Test
     fun `destroying a managed domain calls requests with the correct params`() {
       val overrides = serviceAccountOverrides()
       domains.destroy("dom-123", overrides)
@@ -578,6 +646,27 @@ class DomainsTests {
       assertEquals("v3/admin/domains/dom-123", pathCaptor.firstValue)
       assertEquals(DeleteResponse::class.java, typeCaptor.firstValue)
       assertServiceAccountOverrides(overrides, overrideParamCaptor.firstValue)
+    }
+
+    @Test
+    fun `destroying a managed domain with signer calls requests with signer headers`() {
+      val signer = ServiceAccountSigner(testKeyPair().private, "service-account-key-id")
+
+      domains.destroy("dom-123", signer, RequestOverrides(headers = mapOf("X-Custom" to "keep")))
+
+      val pathCaptor = argumentCaptor<String>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
+        pathCaptor.capture(),
+        any(),
+        anyOrNull(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals("v3/admin/domains/dom-123", pathCaptor.firstValue)
+      assertEquals("keep", overrideParamCaptor.firstValue.headers?.get("X-Custom"))
+      assertEquals("service-account-key-id", overrideParamCaptor.firstValue.headers?.get("X-Nylas-Kid"))
+      assertTrue(overrideParamCaptor.firstValue.omitAuthorization)
     }
 
     @Test
@@ -606,6 +695,31 @@ class DomainsTests {
     }
 
     @Test
+    fun `getting managed domain info with signer calls requests with signer headers`() {
+      val signer = ServiceAccountSigner(testKeyPair().private, "service-account-key-id")
+      val requestBody = DomainVerificationRequest(DomainVerificationRequestType.SPF)
+
+      domains.info("dom-123", requestBody, signer, RequestOverrides(headers = mapOf("X-Custom" to "keep")))
+
+      val pathCaptor = argumentCaptor<String>()
+      val requestBodyCaptor = argumentCaptor<String>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executePostEncoded<Response<DomainVerificationResult>>(
+        pathCaptor.capture(),
+        any(),
+        requestBodyCaptor.capture(),
+        anyOrNull(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals("v3/admin/domains/dom-123/info", pathCaptor.firstValue)
+      assertEquals("""{"type":"spf"}""", requestBodyCaptor.firstValue)
+      assertEquals("keep", overrideParamCaptor.firstValue.headers?.get("X-Custom"))
+      assertEquals("service-account-key-id", overrideParamCaptor.firstValue.headers?.get("X-Nylas-Kid"))
+      assertTrue(overrideParamCaptor.firstValue.omitAuthorization)
+    }
+
+    @Test
     fun `verifying a managed domain calls requests with the correct params`() {
       val requestBody = DomainVerificationRequest(DomainVerificationRequestType.DKIM)
       val overrides = serviceAccountOverrides()
@@ -628,6 +742,31 @@ class DomainsTests {
       assertEquals(Types.newParameterizedType(Response::class.java, DomainVerificationResult::class.java), typeCaptor.firstValue)
       assertEquals("""{"type":"dkim"}""", requestBodyCaptor.firstValue)
       assertServiceAccountOverrides(overrides, overrideParamCaptor.firstValue)
+    }
+
+    @Test
+    fun `verifying a managed domain with signer calls requests with signer headers`() {
+      val signer = ServiceAccountSigner(testKeyPair().private, "service-account-key-id")
+      val requestBody = DomainVerificationRequest(DomainVerificationRequestType.DKIM)
+
+      domains.verify("dom-123", requestBody, signer, RequestOverrides(headers = mapOf("X-Custom" to "keep")))
+
+      val pathCaptor = argumentCaptor<String>()
+      val requestBodyCaptor = argumentCaptor<String>()
+      val overrideParamCaptor = argumentCaptor<RequestOverrides>()
+      verify(mockNylasClient).executePostEncoded<Response<DomainVerificationResult>>(
+        pathCaptor.capture(),
+        any(),
+        requestBodyCaptor.capture(),
+        anyOrNull(),
+        overrideParamCaptor.capture(),
+      )
+
+      assertEquals("v3/admin/domains/dom-123/verify", pathCaptor.firstValue)
+      assertEquals("""{"type":"dkim"}""", requestBodyCaptor.firstValue)
+      assertEquals("keep", overrideParamCaptor.firstValue.headers?.get("X-Custom"))
+      assertEquals("service-account-key-id", overrideParamCaptor.firstValue.headers?.get("X-Nylas-Kid"))
+      assertTrue(overrideParamCaptor.firstValue.omitAuthorization)
     }
 
     private fun assertServiceAccountOverrides(expected: RequestOverrides, actual: RequestOverrides) {

--- a/src/test/kotlin/com/nylas/resources/DraftsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/DraftsTests.kt
@@ -167,7 +167,7 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListDraftsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Draft>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -187,7 +187,7 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListDraftsQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Draft>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -208,7 +208,7 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Draft>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -242,7 +242,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Draft>>(
+      verify(mockNylasClient).executePostEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -276,7 +276,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Draft>>(
+      verify(mockNylasClient).executePostEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -360,7 +360,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Draft>>(
+      verify(mockNylasClient).executePostEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -408,7 +408,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeFormRequest<Response<Draft>>(
+      verify(mockNylasClient).executeFormRequestEncoded<Response<Draft>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -450,7 +450,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Draft>>(
+      verify(mockNylasClient).executePutEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -503,7 +503,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Draft>>(
+      verify(mockNylasClient).executePutEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -547,7 +547,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeFormRequest<Response<Draft>>(
+      verify(mockNylasClient).executeFormRequestEncoded<Response<Draft>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -580,7 +580,7 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Draft>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -618,7 +618,7 @@ class DraftsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Draft>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -641,7 +641,7 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Draft>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -661,7 +661,7 @@ class DraftsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Draft>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/EventsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/EventsTests.kt
@@ -967,7 +967,7 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Event>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -996,7 +996,7 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListImportEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Event>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -1022,7 +1022,7 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<FindEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Event>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -1071,7 +1071,7 @@ class EventsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<CreateEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Event>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -1115,7 +1115,7 @@ class EventsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<UpdateEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Event>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -1153,7 +1153,7 @@ class EventsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<UpdateEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Event>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -1202,7 +1202,7 @@ class EventsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<UpdateEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Event>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -1255,7 +1255,7 @@ class EventsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<UpdateEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Event>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -1308,7 +1308,7 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<DestroyEventQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Event>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -1331,7 +1331,7 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Event>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -1352,7 +1352,7 @@ class EventsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Event>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -1395,7 +1395,7 @@ class EventsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<SendRsvpQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Event>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Event>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -1420,7 +1420,7 @@ class EventsTests {
 
       events.sendRsvp(grantId, eventId, sendRsvpRequest, sendRsvpQueryParams)
       val queryParamCaptor = argumentCaptor<SendRsvpQueryParams>()
-      verify(mockNylasClient).executePost<DeleteResponse>(
+      verify(mockNylasClient).executePostEncoded<DeleteResponse>(
         any(),
         any(),
         any(),

--- a/src/test/kotlin/com/nylas/resources/FoldersTests.kt
+++ b/src/test/kotlin/com/nylas/resources/FoldersTests.kt
@@ -133,7 +133,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -161,7 +161,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -187,7 +187,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -244,7 +244,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -270,7 +270,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -321,7 +321,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -350,7 +350,7 @@ class FoldersTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<Folder>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -382,7 +382,7 @@ class FoldersTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Folder>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -406,7 +406,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Folder>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -428,7 +428,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Folder>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -448,7 +448,7 @@ class FoldersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Folder>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Folder>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/MessagesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/MessagesTests.kt
@@ -226,7 +226,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -251,7 +251,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -276,7 +276,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -301,7 +301,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -321,7 +321,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -343,7 +343,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -366,7 +366,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -389,7 +389,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -419,7 +419,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Message>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -443,7 +443,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Message>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -465,7 +465,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Message>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -485,7 +485,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Message>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -517,7 +517,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<ScheduledMessage>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<ScheduledMessage>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -539,7 +539,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Message>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -561,7 +561,7 @@ class MessagesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<Response<Message>>(
+      verify(mockNylasClient).executeDeleteEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -611,7 +611,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Message>>(
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -646,7 +646,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Message>>(
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -733,7 +733,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Draft>>(
+      verify(mockNylasClient).executePostEncoded<Response<Draft>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -764,7 +764,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Message>>(
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -799,7 +799,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Message>>(
+      verify(mockNylasClient).executePostEncoded<Response<Message>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -851,7 +851,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<RequestBody>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeFormRequest<Response<Message>>(
+      verify(mockNylasClient).executeFormRequestEncoded<Response<Message>>(
         pathCaptor.capture(),
         methodCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -908,7 +908,7 @@ class MessagesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<CleanMessagesResponse>>(
+      verify(mockNylasClient).executePutEncoded<Response<CleanMessagesResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/NotetakersTests.kt
+++ b/src/test/kotlin/com/nylas/resources/NotetakersTests.kt
@@ -173,7 +173,7 @@ class NotetakersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListNotetakersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Notetaker>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Notetaker>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -194,7 +194,7 @@ class NotetakersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Notetaker>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Notetaker>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         isNull(),
@@ -225,7 +225,7 @@ class NotetakersTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Notetaker>>(
+      verify(mockNylasClient).executePostEncoded<Response<Notetaker>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -258,7 +258,7 @@ class NotetakersTests {
       val typeCaptor = argumentCaptor<Type>()
       val requestBodyCaptor = argumentCaptor<String>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Notetaker>>(
+      verify(mockNylasClient).executePutEncoded<Response<Notetaker>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -280,7 +280,7 @@ class NotetakersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<LeaveNotetakerResponse>>(
+      verify(mockNylasClient).executePostEncoded<Response<LeaveNotetakerResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         isNull(),
@@ -301,7 +301,7 @@ class NotetakersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<NotetakerMediaResponse>>(
+      verify(mockNylasClient).executeGetEncoded<Response<NotetakerMediaResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         isNull(),
@@ -322,7 +322,7 @@ class NotetakersTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -343,7 +343,7 @@ class NotetakersTests {
       val pathCaptor = argumentCaptor<String>()
       val typeCaptor = argumentCaptor<Type>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Notetaker>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Notetaker>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         isNull(),

--- a/src/test/kotlin/com/nylas/resources/NylasListsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/NylasListsTests.kt
@@ -165,7 +165,7 @@ class NylasListsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<NylasList>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -186,7 +186,7 @@ class NylasListsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<NylasList>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -206,7 +206,7 @@ class NylasListsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<NylasList>>(
+      verify(mockNylasClient).executeGetEncoded<Response<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -229,7 +229,7 @@ class NylasListsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<NylasList>>(
+      verify(mockNylasClient).executePostEncoded<Response<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -254,7 +254,7 @@ class NylasListsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<NylasList>>(
+      verify(mockNylasClient).executePutEncoded<Response<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -276,7 +276,7 @@ class NylasListsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -297,7 +297,7 @@ class NylasListsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<NylasListItem>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<NylasListItem>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -321,7 +321,7 @@ class NylasListsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<NylasList>>(
+      verify(mockNylasClient).executePostEncoded<Response<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -347,7 +347,7 @@ class NylasListsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<Response<NylasList>>(
+      verify(mockNylasClient).executeDeleteEncoded<Response<NylasList>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/PoliciesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/PoliciesTests.kt
@@ -178,7 +178,7 @@ class PoliciesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Policy>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Policy>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -199,7 +199,7 @@ class PoliciesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Policy>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Policy>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -219,7 +219,7 @@ class PoliciesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Policy>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Policy>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -242,7 +242,7 @@ class PoliciesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Policy>>(
+      verify(mockNylasClient).executePostEncoded<Response<Policy>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -267,7 +267,7 @@ class PoliciesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Policy>>(
+      verify(mockNylasClient).executePutEncoded<Response<Policy>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -289,7 +289,7 @@ class PoliciesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/RedirectUriTests.kt
+++ b/src/test/kotlin/com/nylas/resources/RedirectUriTests.kt
@@ -95,7 +95,7 @@ class RedirectUriTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<RedirectUri>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -115,7 +115,7 @@ class RedirectUriTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<RedirectUri>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -148,7 +148,7 @@ class RedirectUriTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<ListResponse<RedirectUri>>(
+      verify(mockNylasClient).executePostEncoded<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -184,7 +184,7 @@ class RedirectUriTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePatch<ListResponse<RedirectUri>>(
+      verify(mockNylasClient).executePatchEncoded<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -206,7 +206,7 @@ class RedirectUriTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<ListCalendersQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<RedirectUri>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -227,7 +227,7 @@ class RedirectUriTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<RedirectUri>>(
+      verify(mockNylasClient).executeGetEncoded<Response<RedirectUri>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/RulesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/RulesTests.kt
@@ -350,7 +350,7 @@ class RulesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Rule>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Rule>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -381,7 +381,7 @@ class RulesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Rule>>(
+      verify(mockNylasClient).executePostEncoded<Response<Rule>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -406,7 +406,7 @@ class RulesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Rule>>(
+      verify(mockNylasClient).executePutEncoded<Response<Rule>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -428,7 +428,7 @@ class RulesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -449,7 +449,7 @@ class RulesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<RuleEvaluation>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<RuleEvaluation>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/SessionsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/SessionsTest.kt
@@ -79,7 +79,7 @@ class SessionsTest {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Session>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executePostEncoded<Session>(pathCaptor.capture(), typeCaptor.capture(), requestBodyCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
 
       assertEquals("v3/scheduling/sessions", pathCaptor.firstValue)
       assertEquals(Types.newParameterizedType(Response::class.java, Session::class.java), typeCaptor.firstValue)
@@ -95,7 +95,7 @@ class SessionsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(pathCaptor.capture(), typeCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(pathCaptor.capture(), typeCaptor.capture(), queryParamCaptor.capture(), overrideParamCaptor.capture())
       assertEquals("v3/scheduling/sessions/$sessionId", pathCaptor.firstValue)
       assertEquals(DeleteResponse::class.java, typeCaptor.firstValue)
     }
@@ -110,7 +110,7 @@ class SessionsTest {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/ThreadsTests.kt
+++ b/src/test/kotlin/com/nylas/resources/ThreadsTests.kt
@@ -212,7 +212,7 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Thread>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -232,7 +232,7 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Thread>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -254,7 +254,7 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Thread>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -273,7 +273,7 @@ class ThreadsTests {
       threads.find(grantId, threadId)
 
       val pathCaptor = argumentCaptor<String>()
-      verify(mockNylasClient).executeGet<ListResponse<Thread>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         any(),
         anyOrNull(),
@@ -291,7 +291,7 @@ class ThreadsTests {
       threads.update(grantId, threadId, updateThreadRequest)
 
       val pathCaptor = argumentCaptor<String>()
-      verify(mockNylasClient).executePut<ListResponse<Thread>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         any(),
         any(),
@@ -312,7 +312,7 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Thread>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -339,7 +339,7 @@ class ThreadsTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<ListResponse<Thread>>(
+      verify(mockNylasClient).executePutEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -363,7 +363,7 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<ListResponse<Thread>>(
+      verify(mockNylasClient).executeDeleteEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -484,7 +484,7 @@ class ThreadsTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Thread>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Thread>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/WebhooksTests.kt
+++ b/src/test/kotlin/com/nylas/resources/WebhooksTests.kt
@@ -99,7 +99,7 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Webhook>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -120,7 +120,7 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Webhook>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -149,7 +149,7 @@ class WebhooksTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Webhook>>(
+      verify(mockNylasClient).executePostEncoded<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -181,7 +181,7 @@ class WebhooksTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePut<Response<Webhook>>(
+      verify(mockNylasClient).executePutEncoded<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -205,7 +205,7 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -240,7 +240,7 @@ class WebhooksTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Webhook>>(
+      verify(mockNylasClient).executePostEncoded<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -261,7 +261,7 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Webhook>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -299,7 +299,7 @@ class WebhooksTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Webhook>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Webhook>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),

--- a/src/test/kotlin/com/nylas/resources/WorkspacesTests.kt
+++ b/src/test/kotlin/com/nylas/resources/WorkspacesTests.kt
@@ -165,7 +165,7 @@ class WorkspacesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Workspace>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Workspace>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -186,7 +186,7 @@ class WorkspacesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<ListResponse<Workspace>>(
+      verify(mockNylasClient).executeGetEncoded<ListResponse<Workspace>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -206,7 +206,7 @@ class WorkspacesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeGet<Response<Workspace>>(
+      verify(mockNylasClient).executeGetEncoded<Response<Workspace>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -228,7 +228,7 @@ class WorkspacesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<Workspace>>(
+      verify(mockNylasClient).executePostEncoded<Response<Workspace>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -252,7 +252,7 @@ class WorkspacesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePatch<Response<Workspace>>(
+      verify(mockNylasClient).executePatchEncoded<Response<Workspace>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -273,7 +273,7 @@ class WorkspacesTests {
       val typeCaptor = argumentCaptor<Type>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executeDelete<DeleteResponse>(
+      verify(mockNylasClient).executeDeleteEncoded<DeleteResponse>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         queryParamCaptor.capture(),
@@ -295,7 +295,7 @@ class WorkspacesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<WorkspaceAutoGroupResponse>>(
+      verify(mockNylasClient).executePostEncoded<Response<WorkspaceAutoGroupResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),
@@ -319,7 +319,7 @@ class WorkspacesTests {
       val requestBodyCaptor = argumentCaptor<String>()
       val queryParamCaptor = argumentCaptor<IQueryParams>()
       val overrideParamCaptor = argumentCaptor<RequestOverrides>()
-      verify(mockNylasClient).executePost<Response<WorkspaceManualAssignResponse>>(
+      verify(mockNylasClient).executePostEncoded<Response<WorkspaceManualAssignResponse>>(
         pathCaptor.capture(),
         typeCaptor.capture(),
         requestBodyCaptor.capture(),


### PR DESCRIPTION
Related to issue: https://github.com/nylas/nylas-java/issues/329

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.