### PR TITLE
TW-5710: SDK Release 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [unreleased]
+## [v2.17.1] - Release 2026-06-25
 
 ### Fixed
 * Prevent double-encoding of pre-encoded path IDs when building request URLs, fixing Gmail attachment download 404s for attachment IDs containing reserved characters such as `:` and `=`

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ This repository is for contributors and anyone installing the SDK from source. I
 Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.nylas.sdk:nylas:2.17.0")
+implementation("com.nylas.sdk:nylas:2.17.1")
 ```
 
 Groovy (`build.gradle`):
 
 ```groovy
-implementation 'com.nylas.sdk:nylas:2.17.0'
+implementation 'com.nylas.sdk:nylas:2.17.1'
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation 'com.nylas.sdk:nylas:2.17.0'
 <dependency>
   <groupId>com.nylas.sdk</groupId>
   <artifactId>nylas</artifactId>
-  <version>2.17.0</version>
+  <version>2.17.1</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.17.0
+version=2.17.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
## [v2.17.1] - Release 2026-06-25

### Fixed
* Prevent double-encoding of pre-encoded path IDs when building request URLs, fixing Gmail attachment download 404s for attachment IDs containing reserved characters such as `:` and `=`


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.