### PR TITLE
TDT-2790 Clarify event visibility default is Google-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nylas Java SDK Changelog
 
+## [Unreleased]
+
+### Changed
+* Clarify that event `default` visibility is Google-only
+
 ## [v2.17.1] - Release 2026-06-25
 
 ### Fixed

--- a/src/main/kotlin/com/nylas/models/EventVisibility.kt
+++ b/src/main/kotlin/com/nylas/models/EventVisibility.kt
@@ -4,6 +4,10 @@ import com.squareup.moshi.Json
 
 /**
  * Enum representation of visibility of the event, if the event is private or public.
+ *
+ * [DEFAULT] is only valid for Google events, where it defers to the calendar's own sharing
+ * settings. Microsoft and EWS events only support [PUBLIC] and [PRIVATE]; sending `default`
+ * for these providers returns a 400 error.
  */
 enum class EventVisibility {
   @Json(name = "default")


### PR DESCRIPTION
## What

Updates the KDoc for `EventVisibility` in `src/main/kotlin/com/nylas/models/EventVisibility.kt` to note that `DEFAULT` only works for Google events. Microsoft and EWS accounts return a 400 error when `DEFAULT` is sent, but the enum docs didn't warn about this.

Jira: TDT-2790 (sub-task of TDT-2765)

🤖 Generated with [Claude Code](https://claude.com/claude-code)