### PR TITLE
TA-3804: add tentative-as-busy to calendar request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+* `GetFreeBusyRequest.tentativeAsBusy` mapped to the `tentative_as_busy` request field while preserving the existing Java constructor overload for backward compatibility
+
 ### Changed
 * Clarify that event `default` visibility is Google-only
 

--- a/src/main/kotlin/com/nylas/models/GetFreeBusyRequest.kt
+++ b/src/main/kotlin/com/nylas/models/GetFreeBusyRequest.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.Json
 /**
  * Class representation of a Nylas get free-busy request
  */
-data class GetFreeBusyRequest(
+data class GetFreeBusyRequest @JvmOverloads constructor(
   /**
    * Unix timestamp representing the start of the time block for assessing the account's free/busy schedule.
    */
@@ -21,4 +21,9 @@ data class GetFreeBusyRequest(
    */
   @Json(name = "emails")
   val emails: List<String>,
+  /**
+   * When true, tentative events are counted as busy.
+   */
+  @Json(name = "tentative_as_busy")
+  val tentativeAsBusy: Boolean? = null,
 )

--- a/src/test/kotlin/com/nylas/resources/CalendarsTest.kt
+++ b/src/test/kotlin/com/nylas/resources/CalendarsTest.kt
@@ -101,6 +101,38 @@ class CalendarsTest {
       assertEquals(2, cal.notetaker?.rules?.participantFilter?.participantsGte)
       assertEquals(10, cal.notetaker?.rules?.participantFilter?.participantsLte)
     }
+
+    @Test
+    fun `GetFreeBusyRequest serializes tentative as busy when set`() {
+      val adapter = JsonHelper.moshi().adapter(GetFreeBusyRequest::class.java)
+      val request = GetFreeBusyRequest(
+        startTime = 1620000000,
+        endTime = 1620003600,
+        emails = listOf("test@nylas.com"),
+        tentativeAsBusy = true,
+      )
+
+      val json = adapter.toJson(request)
+      val deserialized = adapter.fromJson(json)!!
+
+      assertEquals(true, deserialized.tentativeAsBusy)
+    }
+
+    @Test
+    fun `GetFreeBusyRequest legacy constructor remains backward compatible`() {
+      val adapter = JsonHelper.moshi().adapter(GetFreeBusyRequest::class.java)
+      val request = GetFreeBusyRequest(
+        1620000000,
+        1620003600,
+        listOf("test@nylas.com"),
+      )
+
+      val json = adapter.toJson(request)
+      val deserialized = adapter.fromJson(json)!!
+
+      assertEquals(null, deserialized.tentativeAsBusy)
+      assertEquals(false, json.contains("tentative_as_busy"))
+    }
   }
 
   @Nested
@@ -923,6 +955,7 @@ class CalendarsTest {
         startTime = 1620000000,
         endTime = 1620000000,
         emails = listOf("test@nylas.com"),
+        tentativeAsBusy = true,
       )
 
       calendars.getFreeBusy(grantId, getFreeBusyRequest)


### PR DESCRIPTION
## Summary

  Adds optional tentative_as_busy support to GetFreeBusyRequest in the Java SDK.

  ## Changes

  - Added tentativeAsBusy: Boolean? = null to GetFreeBusyRequest
  - Preserved backward compatibility for Java callers with @JvmOverloads
  - Added unit tests for:
      - serializing tentative_as_busy when set
      - legacy 3-arg constructor compatibility
      - free-busy request body coverage

  - Updated CHANGELOG.md

  ## Validation

  - ./gradlew test --tests com.nylas.resources.CalendarsTest
  - ./gradlew build

# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.