### PR TITLE
SDK Release: v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## [Unreleased]
+## [v2.18.0] - Release 2026-07-10
 
 ### Added
 * `GetFreeBusyRequest.tentativeAsBusy` mapped to the `tentative_as_busy` request field while preserving the existing Java constructor overload for backward compatibility

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ This repository is for contributors and anyone installing the SDK from source. I
 Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.nylas.sdk:nylas:2.17.1")
+implementation("com.nylas.sdk:nylas:2.18.0")
 ```
 
 Groovy (`build.gradle`):
 
 ```groovy
-implementation 'com.nylas.sdk:nylas:2.17.1'
+implementation 'com.nylas.sdk:nylas:2.18.0'
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation 'com.nylas.sdk:nylas:2.17.1'
 <dependency>
   <groupId>com.nylas.sdk</groupId>
   <artifactId>nylas</artifactId>
-  <version>2.17.1</version>
+  <version>2.18.0</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.17.1
+version=2.18.0
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
## [v2.18.0] - Release 2026-07-10

### Added
* `GetFreeBusyRequest.tentativeAsBusy` mapped to the `tentative_as_busy` request field while preserving the existing Java constructor overload for backward compatibility

### Changed
* Clarify that event `default` visibility is Google-only


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.