### PR TITLE
Release v2.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nylas Java SDK Changelog
 
-## Unreleased
+## [v2.18.1] - Release 2026-08-18
 
 ### Added
 * Optional `TrackingOptions.domainName` support for custom link and open tracking hostnames in regular sends, Transactional Send, drafts, and scheduled sends. The field serializes as `tracking_options.domain_name` and is omitted when unset.

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ This repository is for contributors and anyone installing the SDK from source. I
 Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.nylas.sdk:nylas:2.18.0")
+implementation("com.nylas.sdk:nylas:2.18.1")
 ```
 
 Groovy (`build.gradle`):
 
 ```groovy
-implementation 'com.nylas.sdk:nylas:2.18.0'
+implementation 'com.nylas.sdk:nylas:2.18.1'
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation 'com.nylas.sdk:nylas:2.18.0'
 <dependency>
   <groupId>com.nylas.sdk</groupId>
   <artifactId>nylas</artifactId>
-  <version>2.18.0</version>
+  <version>2.18.1</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.nylas.sdk
-version=2.18.0
+version=2.18.1
 
 # Override and set these in ~/.gradle/gradle.properties
 ossrhUser=


### PR DESCRIPTION
## [v2.18.1] - Release 2026-08-18

### Added
* Optional `TrackingOptions.domainName` support for custom link and open tracking hostnames in regular sends, Transactional Send, drafts, and scheduled sends. The field serializes as `tracking_options.domain_name` and is omitted when unset.

### Fixed
* `metadata_pair` (calendars, events, messages) is now sent as a single `key:value` query parameter using the first map entry, instead of one repeated parameter per entry. The API accepts exactly one pair, so maps with more than one entry previously had all but one entry silently ignored. Public types are unchanged (`Map<String, String>`); single-entry and empty maps produce the same request as before.
* `to`, `from`, `cc`, `bcc`, and `in` (messages, threads, drafts) are now sent as a single query parameter using the first list entry, instead of as repeated parameters. The API binds each as a scalar string and validates `to`/`from`/`cc`/`bcc` as one email address, so repeated parameters meant the API silently kept just one value — whichever its parser happened to keep last. Sending one parameter makes that deterministic and matches the behavior `inFolder` already documented. Public types are unchanged (`List<String>`); passing a single-element list produces the same request as before. These parameters will change type to `String` in a future major version.
* `attendees` (events) and `any_email` (messages, threads, drafts) are now sent as a single comma-delimited query parameter instead of repeated parameters. The API parses both as comma-delimited strings, so passing more than one value previously caused the API to keep only the last one, returning silently incorrect, order-dependent results. Public types are unchanged (`List<String>`), and null, empty, and single-element values produce the same request as before. Note that `any_email` accepts at most 25 addresses; over-long lists now surface an API validation error instead of silently filtering on a single address. `event_type` is unaffected — the API genuinely supports repeating it.


# License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.